### PR TITLE
bug/admin/after_sign_in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,6 @@
-# frozen_string_literal: true
-
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
-  # ログイン済ユーザーのみにアクセスを許可する
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_current_user
-
-  # protect_from_forgery
-  def after_sign_in_path_for(resource)#usersコントローラーのshowアクションを呼び出すパスを設定  ここに追加するのか？
-    users_show_path
-  end
-
-  before_action :set_current_user
 
   def after_sign_in_path_for(resource)
     case resource
@@ -30,9 +18,5 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
     devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
-  end
-
-  def set_current_user
-    @current_user = User.find_by(id: session[user_session])
   end
 end


### PR DESCRIPTION
### 概要
バグ修正管理者ログイン遷移先

### タスク
- [x]あり 
- https://trello.com/c/ppQluVX6/103-%E7%AE%A1%E7%90%86%E8%80%85%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%AE%E9%81%B7%E7%A7%BB%E5%85%88-%E4%BF%AE%E6%AD%A3

### 実装内容・手法
ApplicationControllerによりuserのsignInの有無の振り分けのメソッドを書いていた事によりバグが発生。
しかし機能していなく、このメソッドの在る無し関係なく動画一覧（全ユーザー）でcurrent_userのidが探せないエラーになる為削除しました。

### 実装画像などあれば添付する
#### before
![スクリーンショット 2022-12-09 013646](https://user-images.githubusercontent.com/67591423/206510310-75cc7f63-3f34-4f5b-a5c9-2bf0d62061f1.jpg)
#### after
![スクリーンショット 2022-12-09 005543](https://user-images.githubusercontent.com/67591423/206510383-2843b0e2-7535-4c9b-b3c1-afe60eb2a0ea.jpg)
#### error
![スクリーンショット 2022-12-06 052404](https://user-images.githubusercontent.com/67591423/206510482-5de2cb63-a321-4ed2-942f-2854c6fd6e60.jpg)