### PR TITLE
Yosei/bug/index table without record

### DIFF
--- a/app/views/admins/articles/shared/_articles_table.html.erb
+++ b/app/views/admins/articles/shared/_articles_table.html.erb
@@ -15,23 +15,29 @@
             </tr>
           </thead>
           <tbody>
-            <% colspan = dashboard ? 2 : 3 %>
-            <tr class="nohover">
-              <td colspan="<%= colspan %>" class="search"></td>
-            </tr>
-            <% @articles.each do |a| %>
-              <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                <td>
-                  <%= a.title %>
-                  <% if a.sub_title.present? %>
-                    <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
-                  <% end %>
-                </td>
-                <% if !dashboard %>
-                  <td><%= @users.find(a.user_id).name %></td>
-                <% end %>
-                <td><%= l(a.created_at, format: :long) %></td>
+            <% if @articles.exists? %>
+              <% colspan = dashboard ? 2 : 3 %>
+              <tr class="nohover">
+                <td colspan="<%= colspan %>" class="search"></td>
               </tr>
+              <% @articles.each do |a| %>
+                <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
+                  <td>
+                    <%= a.title %>
+                    <% if a.sub_title.present? %>
+                      <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
+                    <% end %>
+                  </td>
+                  <% if !dashboard %>
+                    <td><%= @users.find(a.user_id).name %></td>
+                  <% end %>
+                  <td><%= l(a.created_at, format: :long) %></td>
+                </tr>
+              <% end %>
+            <% else %>
+              <tr>
+                <td colspan="100" class="text-center py-5">投稿なし</tr>
+              </tr>                
             <% end %>
           </tbody>
         </table>

--- a/app/views/admins/profiles/index.html.erb
+++ b/app/views/admins/profiles/index.html.erb
@@ -13,20 +13,26 @@
           </tr>
         </thead>
         <tbody>
-          <% @users.each do |u| %>
+          <% if @users.exists? %>
+            <% @users.each do |u| %>
+              <tr>
+                <td><%= u.name %></td>
+                <td><%= u.email %></td>
+                <td><%= u.articles.count %></td>
+                <td><%= u.posts.count %></td>
+                <td>
+                  <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
+                  <ul class="dropdown-menu">
+                    <li><%= link_to '詳細', users_show_admins_profiles_path(u.id), class:"nav-link" %></li>
+                    <li><%= link_to '編集', users_edit_admins_profiles_path(u.id), class:"nav-link" %></li>
+                    <li><%= link_to '削除', user_destroy_admins_profiles_path(u.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li>
+                  </ul>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
             <tr>
-              <td><%= u.name %></td>
-              <td><%= u.email %></td>
-              <td><%= u.articles.count %></td>
-              <td><%= u.posts.count %></td>
-              <td>
-                <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
-                <ul class="dropdown-menu">
-                  <li><%= link_to '詳細', users_show_admins_profiles_path(u.id), class:"nav-link" %></li>
-                  <li><%= link_to '編集', users_edit_admins_profiles_path(u.id), class:"nav-link" %></li>
-                  <li><%= link_to '削除', user_destroy_admins_profiles_path(u.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li>
-                </ul>
-              </td>
+              <td colspan="100" class="text-center py-5">登録ユーザーなし</tr>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -13,19 +13,23 @@
             </tr>
           </thead>
           <tbody>
-            <% @articles.each do |a| %>
-              <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                <td>
-                  <%= a.title %>
-                  <% if a.sub_title.present? %>
-                    <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
+            <% if @articles.exists? %>
+              <% @articles.each do |a| %>
+                <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
+                  <td>
+                    <%= a.title %>
+                    <% if a.sub_title.present? %>
+                      <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
+                    <% end %>
+                  </td>
+                  <% if !dashboard %>
+                    <td><%= @users.find(a.user_id).name %></td>
                   <% end %>
-                </td>
-                <% if !dashboard %>
-                  <td><%= @users.find(a.user_id).name %></td>
-                <% end %>
-                <td><%= l(a.created_at, format: :long) %></td>
-              </tr>
+                  <td><%= l(a.created_at, format: :long) %></td>
+                </tr>
+              <% end %>
+            <% else %>
+              <%= render 'users/shared/table_without_record' %>
             <% end %>
           </tbody>
         </table>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -16,17 +16,21 @@
         </tr>
       </thead>
 
-      <tbody>
-        <% @posts.each do |post| %>
-          <tr>
-            <td width="230"><%= post.title %></td>
-            <td width="230"><%= simple_format(post.body) %></td>
-            <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
-            <td>
-              <%= button_to '動画詳細', users_post_path(post), method: :get, class: "btn btn-warning" %><br>
-              <%= button_to '削除', users_post_path(post), method: :delete, class: "btn btn-danger", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %>
-            </td>
-          </tr>
+      <tbody>      
+        <% if @posts.exists? %>
+          <% @posts.each do |post| %>
+            <tr>
+              <td width="230"><%= post.title %></td>
+              <td width="230"><%= simple_format(post.body) %></td>
+              <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
+              <td>
+                <%= button_to '動画詳細', users_post_path(post), method: :get, class: "btn btn-warning" %><br>
+                <%= button_to '削除', users_post_path(post), method: :delete, class: "btn btn-danger", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <%= render 'users/shared/table_without_record' %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -34,3 +34,4 @@
         <% end %>
       </tbody>
     </table>
+    

--- a/app/views/users/posts/index_1.html.erb
+++ b/app/views/users/posts/index_1.html.erb
@@ -17,19 +17,23 @@
       </thead>
 
       <tbody>
-        <% @posts.each do |post| %>
-          <tr>
-            <td><%= "↓（#{post.user.name}さんの投稿）" %></td>
-          </tr>
-          <tr>
-            <td width="230"><br><%= post.title %></td>
-            <td width="230"><%= simple_format(post.body) %></td>
-            <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
-            <td>
-              <%= button_to '動画詳細', show_1_users_post_path(post), method: :get, class: "btn btn-warning" %><br>
-              <%= button_to '削除', users_post_path(post.user.id, post.id), method: :delete, class: "btn btn-danger" %>
-            </td>
-          </tr>
+        <% if @posts.exists? %>
+          <% @posts.each do |post| %>
+            <tr>
+              <td><%= "↓（#{post.user.name}さんの投稿）" %></td>
+            </tr>
+            <tr>
+              <td width="230"><br><%= post.title %></td>
+              <td width="230"><%= simple_format(post.body) %></td>
+              <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
+              <td>
+                <%= button_to '動画詳細', show_1_users_post_path(post), method: :get, class: "btn btn-warning" %><br>
+                <%= button_to '削除', users_post_path(post.user.id, post.id), method: :delete, class: "btn btn-danger" %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <%= render 'users/shared/table_without_record' %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/users/profiles/index.html.erb
+++ b/app/views/users/profiles/index.html.erb
@@ -9,32 +9,36 @@
           </tr>
         </thead>
         <tbody>
-          <% @profiles.each do |profile| %>
-            <tr>
-              <td><%= link_to(profile.name, "/users/profiles/#{profile.id}", method: :get) %></td>
-            </tr>
-          <% end %>
-          <% @profiles.each do |profile| %>
-          <tr>
-            <td>
-              <%= profile.id %>
-            </td>
-            <td>
-              <%= profile.title %>
-            </td>
-            <td>
-              <%= profile.name %>
-            </td>
-            <td>
-              <%= profile.created_at.to_s(:datetime_jp) %>
-            </td>
-            <td>
-              <%= profile.updated_at.to_s(:datetime_jp) %>
-            </td>
-            <td>
-              <%= link_to '詳細', profile, class: 'btn btn-outline-dark' %>
-            </td>
-          </tr>
+          <% if @profiles.exists? %>
+            <% @profiles.each do |profile| %>
+              <tr>
+                <td><%= link_to(profile.name, "/users/profiles/#{profile.id}", method: :get) %></td>
+              </tr>
+            <% end %>
+            <% @profiles.each do |profile| %>
+              <tr>
+                <td>
+                  <%= profile.id %>
+                </td>
+                <td>
+                  <%= profile.title %>
+                </td>
+                <td>
+                  <%= profile.name %>
+                </td>
+                <td>
+                  <%= profile.created_at.to_s(:datetime_jp) %>
+                </td>
+                <td>
+                  <%= profile.updated_at.to_s(:datetime_jp) %>
+                </td>
+                <td>
+                  <%= link_to '詳細', profile, class: 'btn btn-outline-dark' %>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <%= render 'users/shared/table_without_record' %>
           <% end %>
         </tbody>
       </table>

--- a/app/views/users/shared/_table_without_record.html.erb
+++ b/app/views/users/shared/_table_without_record.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan='100' class="text-center py-5">投稿なし</td>
+</tr>


### PR DESCRIPTION
### 概要
各一覧ページのテーブルにレコードがない場合の表示修正。バグ。

### 実装内容・手法
ユーザー側はrender(partial)を使って共通化。
管理側は各ページで対応。

### 実装画像などあれば添付する
![スクリーンショット 2022-12-11 21 09 51](https://user-images.githubusercontent.com/59328464/206903237-7051b4db-c40d-416c-b79b-2f3f63eba59d.png)
![スクリーンショット 2022-12-11 21 09 21](https://user-images.githubusercontent.com/59328464/206903253-f14fcb63-fde1-4070-a11a-8b3da3188f8c.png)
![スクリーンショット 2022-12-11 21 09 28](https://user-images.githubusercontent.com/59328464/206903247-79fc57aa-b5d5-4072-8fcd-be7724d90e9d.png)
![スクリーンショット 2022-12-11 21 09 14](https://user-images.githubusercontent.com/59328464/206903257-6c167a5c-b3b4-4c88-b8f2-d1661fe55086.png)
![スクリーンショット 2022-12-11 21 05 52](https://user-images.githubusercontent.com/59328464/206903269-dc7e1d9c-0937-4691-b940-53b22e5a1501.png)
![スクリーンショット 2022-12-11 21 06 05](https://user-images.githubusercontent.com/59328464/206903378-1f877d59-9998-444e-94ef-1226f5a3d74e.png)
