### PR TITLE
Yosei/fix/new article page

### DIFF
--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -2,36 +2,19 @@ import { marked } from 'marked'
 import "./articles"
 
 $(function(){
-
-  var elem = $('.editor-side .card')
-  var height = elem.height() + $('.div-btns').height();
-  elem.height(height);
-  $('.preview-side .card').height(height);
-
-  var elem = $(".div-textarea");
-  var height = elem.position().top + $(".markdown-editor").height();
-  elem = $(".div-title-form");
-  height -= elem.position().top;
-  height -= $(".div-btns").height();
-  $(".preview").height(height);
   
-  $('.title-form').keyup(function(event){
-    var title = $(this).val();
-    title ||= "タイトル"
-    $('.preview-title').text(title);
-  });
-
-  $('.subtitle-form').keyup(function(){
-    var subtitle = $(this).val();
-    subtitle ||= "サブタイトル"
-    $('.preview-subtitle').text(subtitle);
-  });
-
+  var m_editor = $(".markdown-editor");
+  var preview = $(".preview");
+  preview.height(m_editor.height());
+  preview.css('color', m_editor.css('color'));
+  preview.html(preview.data("preview-content"));
+  $('.editor-side .card').height($('.preview-side .card').height())
+  
   if($(".markdown-editor").val()){
     var content = $(".markdown-editor").text()
     content = mathtodollars(content);
     content = marked(content)
-    var elem = $('.preview-content')
+    var elem = $('.preview')
     elem.html(content);
     var pre = elem.find('pre');
     pre.each(function(){
@@ -48,7 +31,7 @@ $(function(){
     content ||= "コンテンツ"
     content = marked(content);
     content ||= "コンテンツ"
-    var pre = $('.preview-content')
+    var pre = $('.preview')
     pre.html(content);
     pre.find("img").each(function(){
       $(this).width("60%")
@@ -96,8 +79,8 @@ $(function(){
     sentence = before + word + after;
     textarea.value = sentence;
     var content = marked(textarea.value)
-    $(".preview-content").html(content);
-    resize_img($(".preview-content"))
+    $(".preview").html(content);
+    resize_img($(".preview"))
   }
 
 });

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -24,6 +24,8 @@ $(function(){
       $(this).width("60%")
       $(this).height("60%")
     })
+  }else{
+    $('.preview').html("コンテンツ");
   }
 
   $('.markdown-editor').keyup(function(event){

--- a/app/views/admins/articles/shared/_articles_table.html.erb
+++ b/app/views/admins/articles/shared/_articles_table.html.erb
@@ -15,23 +15,29 @@
             </tr>
           </thead>
           <tbody>
-            <% colspan = dashboard ? 2 : 3 %>
-            <tr class="nohover">
-              <td colspan="<%= colspan %>" class="search"></td>
-            </tr>
-            <% @articles.each do |a| %>
-              <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                <td>
-                  <%= a.title %>
-                  <% if a.sub_title.present? %>
-                    <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
-                  <% end %>
-                </td>
-                <% if !dashboard %>
-                  <td><%= @users.find(a.user_id).name %></td>
-                <% end %>
-                <td><%= l(a.created_at, format: :long) %></td>
+            <% if @articles.exists? %>
+              <% colspan = dashboard ? 2 : 3 %>
+              <tr class="nohover">
+                <td colspan="<%= colspan %>" class="search"></td>
               </tr>
+              <% @articles.each do |a| %>
+                <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
+                  <td>
+                    <%= a.title %>
+                    <% if a.sub_title.present? %>
+                      <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
+                    <% end %>
+                  </td>
+                  <% if !dashboard %>
+                    <td><%= @users.find(a.user_id).name %></td>
+                  <% end %>
+                  <td><%= l(a.created_at, format: :long) %></td>
+                </tr>
+              <% end %>
+            <% else %>
+              <tr>
+                <td colspan="100" class="text-center py-5">投稿なし</tr>
+              </tr>                
             <% end %>
           </tbody>
         </table>

--- a/app/views/admins/profiles/index.html.erb
+++ b/app/views/admins/profiles/index.html.erb
@@ -13,20 +13,26 @@
           </tr>
         </thead>
         <tbody>
-          <% @users.each do |u| %>
+          <% if @users.exists? %>
+            <% @users.each do |u| %>
+              <tr>
+                <td><%= u.name %></td>
+                <td><%= u.email %></td>
+                <td><%= u.articles.count %></td>
+                <td><%= u.posts.count %></td>
+                <td>
+                  <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
+                  <ul class="dropdown-menu">
+                    <li><%= link_to '詳細', users_show_admins_profiles_path(u.id), class:"nav-link" %></li>
+                    <li><%= link_to '編集', users_edit_admins_profiles_path(u.id), class:"nav-link" %></li>
+                    <li><%= link_to '削除', user_destroy_admins_profiles_path(u.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li>
+                  </ul>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
             <tr>
-              <td><%= u.name %></td>
-              <td><%= u.email %></td>
-              <td><%= u.articles.count %></td>
-              <td><%= u.posts.count %></td>
-              <td>
-                <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
-                <ul class="dropdown-menu">
-                  <li><%= link_to '詳細', users_show_admins_profiles_path(u.id), class:"nav-link" %></li>
-                  <li><%= link_to '編集', users_edit_admins_profiles_path(u.id), class:"nav-link" %></li>
-                  <li><%= link_to '削除', user_destroy_admins_profiles_path(u.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li>
-                </ul>
-              </td>
+              <td colspan="100" class="text-center py-5">登録ユーザーなし</tr>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -1,18 +1,19 @@
 <%= form_with(model: @article, url: url, method: method, local: true) do |f| %>
   <div class="row mt-4">
-    <div class="col-6 editor-side">
+    <div class="col-10 offset-1 div-title-form">
+      <%= f.text_field :title, placeholder: "タイトル", class: "form-control title-form" %>
+    </div>
+    <div class="col-10 offset-1 my-2">
+      <%= f.text_field :sub_title, placeholder: "サブタイトル", class: "form-control subtitle-form" %>
+    </div>
+    
+    <div class="col-5 offset-1 editor-side">
       <div class="card card-outline card-info">
         <div class="card-header">
           <h3 class="card-title text-center">エディター</h3>
         </div>
         <div class="card-body">
-          <div class="col-10 offset-1 mt-3 div-title-form">
-            <%= f.text_field :title, placeholder: "タイトル", class: "form-control title-form" %>
-          </div>
-          <div class="col-10 offset-1 mt-3">
-            <%= f.text_field :sub_title, placeholder: "サブタイトル", class: "form-control subtitle-form" %>
-          </div>
-          <div class="col-10 offset-1 mt-3 div-textarea">
+          <div class="col-12 div-textarea">
             <%= f.text_area :content, placeholder: "コンテンツ", cols: 30, rows: 100,
              class: "form-control markdown-editor", data: {user_id: current_user.id} %>
           </div>
@@ -20,24 +21,16 @@
       </div>
     </div>
 
-    <div class="col-6 preview-side">
+    <div class="col-5 preview-side">
       <div class="card card-outline card-info d-flex flex-column justify-content-start">
         <div class="card-header">
           <h3 class="card-title">プレビュー</h3>
         </div>
-        <div class="card-body">
-          <div class="sticky col-10 offset-1">
-            <div class="preview form-control mt-3">
-              <div class="ml-4">
-                <h2><span class="preview-title"><%= @article.title ? @article.title : "タイトル" %></span></h2>
-                <h5 class="mx-3">〜<span class="preview-subtitle"><%= @article.sub_title ? @article.sub_title : "サブタイトル" %></span>〜</h5>
-              </div>
-              <div class="hr"></div>
-              <div class="px-2 preview-content">
-                <%= @article.content ? simple_format(@article.content) : "コンテンツ" %>
-              </div>
-            </div>
-            <div class="text-center div-btns mt-4">
+        <div class="card-body col-12">
+          <div class="sticky">
+            <% content = @article.content ? simple_format(@article.content) : "コンテンツ" %>
+            <div class="preview form-control" data-preview-content='<%= content %>'></div>
+            <div class="text-center div-btns mt-2">
               <%= f.submit btn_name, class: "btn btn-primary" %>
               <%= link_to 'キャンセル', users_article_path(@article, dashboard: true), class: "btn btn-outline-dark" if btn_name == "更新" %>
             </div>

--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -13,19 +13,23 @@
             </tr>
           </thead>
           <tbody>
-            <% @articles.each do |a| %>
-              <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                <td>
-                  <%= a.title %>
-                  <% if a.sub_title.present? %>
-                    <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
+            <% if @articles.exists? %>
+              <% @articles.each do |a| %>
+                <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
+                  <td>
+                    <%= a.title %>
+                    <% if a.sub_title.present? %>
+                      <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
+                    <% end %>
+                  </td>
+                  <% if !dashboard %>
+                    <td><%= @users.find(a.user_id).name %></td>
                   <% end %>
-                </td>
-                <% if !dashboard %>
-                  <td><%= @users.find(a.user_id).name %></td>
-                <% end %>
-                <td><%= l(a.created_at, format: :long) %></td>
-              </tr>
+                  <td><%= l(a.created_at, format: :long) %></td>
+                </tr>
+              <% end %>
+            <% else %>
+              <%= render 'users/shared/table_without_record' %>
             <% end %>
           </tbody>
         </table>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -16,17 +16,21 @@
         </tr>
       </thead>
 
-      <tbody>
-        <% @posts.each do |post| %>
-          <tr>
-            <td width="230"><%= post.title %></td>
-            <td width="230"><%= simple_format(post.body) %></td>
-            <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
-            <td>
-              <%= button_to '動画詳細', users_post_path(post), method: :get, class: "btn btn-warning" %><br>
-              <%= button_to '削除', users_post_path(post), method: :delete, class: "btn btn-danger", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %>
-            </td>
-          </tr>
+      <tbody>      
+        <% if @posts.exists? %>
+          <% @posts.each do |post| %>
+            <tr>
+              <td width="230"><%= post.title %></td>
+              <td width="230"><%= simple_format(post.body) %></td>
+              <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
+              <td>
+                <%= button_to '動画詳細', users_post_path(post), method: :get, class: "btn btn-warning" %><br>
+                <%= button_to '削除', users_post_path(post), method: :delete, class: "btn btn-danger", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <%= render 'users/shared/table_without_record' %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -34,3 +34,4 @@
         <% end %>
       </tbody>
     </table>
+    

--- a/app/views/users/posts/index_1.html.erb
+++ b/app/views/users/posts/index_1.html.erb
@@ -17,19 +17,23 @@
       </thead>
 
       <tbody>
-        <% @posts.each do |post| %>
-          <tr>
-            <td><%= "↓（#{post.user.name}さんの投稿）" %></td>
-          </tr>
-          <tr>
-            <td width="230"><br><%= post.title %></td>
-            <td width="230"><%= simple_format(post.body) %></td>
-            <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
-            <td>
-              <%= button_to '動画詳細', show_1_users_post_path(post), method: :get, class: "btn btn-warning" %><br>
-              <%= button_to '削除', users_post_path(post.user.id, post.id), method: :delete, class: "btn btn-danger" %>
-            </td>
-          </tr>
+        <% if @posts.exists? %>
+          <% @posts.each do |post| %>
+            <tr>
+              <td><%= "↓（#{post.user.name}さんの投稿）" %></td>
+            </tr>
+            <tr>
+              <td width="230"><br><%= post.title %></td>
+              <td width="230"><%= simple_format(post.body) %></td>
+              <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
+              <td>
+                <%= button_to '動画詳細', show_1_users_post_path(post), method: :get, class: "btn btn-warning" %><br>
+                <%= button_to '削除', users_post_path(post.user.id, post.id), method: :delete, class: "btn btn-danger" %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <%= render 'users/shared/table_without_record' %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/users/profiles/index.html.erb
+++ b/app/views/users/profiles/index.html.erb
@@ -9,32 +9,36 @@
           </tr>
         </thead>
         <tbody>
-          <% @profiles.each do |profile| %>
-            <tr>
-              <td><%= link_to(profile.name, "/users/profiles/#{profile.id}", method: :get) %></td>
-            </tr>
-          <% end %>
-          <% @profiles.each do |profile| %>
-          <tr>
-            <td>
-              <%= profile.id %>
-            </td>
-            <td>
-              <%= profile.title %>
-            </td>
-            <td>
-              <%= profile.name %>
-            </td>
-            <td>
-              <%= profile.created_at.to_s(:datetime_jp) %>
-            </td>
-            <td>
-              <%= profile.updated_at.to_s(:datetime_jp) %>
-            </td>
-            <td>
-              <%= link_to '詳細', profile, class: 'btn btn-outline-dark' %>
-            </td>
-          </tr>
+          <% if @profiles.exists? %>
+            <% @profiles.each do |profile| %>
+              <tr>
+                <td><%= link_to(profile.name, "/users/profiles/#{profile.id}", method: :get) %></td>
+              </tr>
+            <% end %>
+            <% @profiles.each do |profile| %>
+              <tr>
+                <td>
+                  <%= profile.id %>
+                </td>
+                <td>
+                  <%= profile.title %>
+                </td>
+                <td>
+                  <%= profile.name %>
+                </td>
+                <td>
+                  <%= profile.created_at.to_s(:datetime_jp) %>
+                </td>
+                <td>
+                  <%= profile.updated_at.to_s(:datetime_jp) %>
+                </td>
+                <td>
+                  <%= link_to '詳細', profile, class: 'btn btn-outline-dark' %>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <%= render 'users/shared/table_without_record' %>
           <% end %>
         </tbody>
       </table>

--- a/app/views/users/shared/_table_without_record.html.erb
+++ b/app/views/users/shared/_table_without_record.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan='100' class="text-center py-5">投稿なし</td>
+</tr>


### PR DESCRIPTION
### 概要
記事投稿ページと記事編集ページのタイトルとサブタイトルフォームを上に分離させる実装。

### 実装画像などあれば添付する
![スクリーンショット 2022-12-17 18 20 58](https://user-images.githubusercontent.com/59328464/208235120-6a2cf02b-ac45-4526-87e5-f58c7061c040.png)
![スクリーンショット 2022-12-17 18 21 22](https://user-images.githubusercontent.com/59328464/208235121-ba131951-e784-4df8-a9b3-b6ad0564b548.png)


