### PR TITLE
Yosei/fix/new article page

### DIFF
--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -2,36 +2,19 @@ import { marked } from 'marked'
 import "./articles"
 
 $(function(){
-
-  var elem = $('.editor-side .card')
-  var height = elem.height() + $('.div-btns').height();
-  elem.height(height);
-  $('.preview-side .card').height(height);
-
-  var elem = $(".div-textarea");
-  var height = elem.position().top + $(".markdown-editor").height();
-  elem = $(".div-title-form");
-  height -= elem.position().top;
-  height -= $(".div-btns").height();
-  $(".preview").height(height);
   
-  $('.title-form').keyup(function(event){
-    var title = $(this).val();
-    title ||= "タイトル"
-    $('.preview-title').text(title);
-  });
-
-  $('.subtitle-form').keyup(function(){
-    var subtitle = $(this).val();
-    subtitle ||= "サブタイトル"
-    $('.preview-subtitle').text(subtitle);
-  });
-
+  var m_editor = $(".markdown-editor");
+  var preview = $(".preview");
+  preview.height(m_editor.height());
+  preview.css('color', m_editor.css('color'));
+  preview.html(preview.data("preview-content"));
+  $('.editor-side .card').height($('.preview-side .card').height())
+  
   if($(".markdown-editor").val()){
     var content = $(".markdown-editor").text()
     content = mathtodollars(content);
     content = marked(content)
-    var elem = $('.preview-content')
+    var elem = $('.preview')
     elem.html(content);
     var pre = elem.find('pre');
     pre.each(function(){
@@ -48,7 +31,7 @@ $(function(){
     content ||= "コンテンツ"
     content = marked(content);
     content ||= "コンテンツ"
-    var pre = $('.preview-content')
+    var pre = $('.preview')
     pre.html(content);
     pre.find("img").each(function(){
       $(this).width("60%")
@@ -96,8 +79,8 @@ $(function(){
     sentence = before + word + after;
     textarea.value = sentence;
     var content = marked(textarea.value)
-    $(".preview-content").html(content);
-    resize_img($(".preview-content"))
+    $(".preview").html(content);
+    resize_img($(".preview"))
   }
 
 });

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -24,6 +24,8 @@ $(function(){
       $(this).width("60%")
       $(this).height("60%")
     })
+  }else{
+    $('.preview').html("コンテンツ");
   }
 
   $('.markdown-editor').keyup(function(event){

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -1,18 +1,19 @@
 <%= form_with(model: @article, url: url, method: method, local: true) do |f| %>
   <div class="row mt-4">
-    <div class="col-6 editor-side">
+    <div class="col-10 offset-1 div-title-form">
+      <%= f.text_field :title, placeholder: "タイトル", class: "form-control title-form" %>
+    </div>
+    <div class="col-10 offset-1 my-2">
+      <%= f.text_field :sub_title, placeholder: "サブタイトル", class: "form-control subtitle-form" %>
+    </div>
+    
+    <div class="col-5 offset-1 editor-side">
       <div class="card card-outline card-info">
         <div class="card-header">
           <h3 class="card-title text-center">エディター</h3>
         </div>
         <div class="card-body">
-          <div class="col-10 offset-1 mt-3 div-title-form">
-            <%= f.text_field :title, placeholder: "タイトル", class: "form-control title-form" %>
-          </div>
-          <div class="col-10 offset-1 mt-3">
-            <%= f.text_field :sub_title, placeholder: "サブタイトル", class: "form-control subtitle-form" %>
-          </div>
-          <div class="col-10 offset-1 mt-3 div-textarea">
+          <div class="col-12 div-textarea">
             <%= f.text_area :content, placeholder: "コンテンツ", cols: 30, rows: 100,
              class: "form-control markdown-editor", data: {user_id: current_user.id} %>
           </div>
@@ -20,24 +21,16 @@
       </div>
     </div>
 
-    <div class="col-6 preview-side">
+    <div class="col-5 preview-side">
       <div class="card card-outline card-info d-flex flex-column justify-content-start">
         <div class="card-header">
           <h3 class="card-title">プレビュー</h3>
         </div>
-        <div class="card-body">
-          <div class="sticky col-10 offset-1">
-            <div class="preview form-control mt-3">
-              <div class="ml-4">
-                <h2><span class="preview-title"><%= @article.title ? @article.title : "タイトル" %></span></h2>
-                <h5 class="mx-3">〜<span class="preview-subtitle"><%= @article.sub_title ? @article.sub_title : "サブタイトル" %></span>〜</h5>
-              </div>
-              <div class="hr"></div>
-              <div class="px-2 preview-content">
-                <%= @article.content ? simple_format(@article.content) : "コンテンツ" %>
-              </div>
-            </div>
-            <div class="text-center div-btns mt-4">
+        <div class="card-body col-12">
+          <div class="sticky">
+            <% content = @article.content ? simple_format(@article.content) : "コンテンツ" %>
+            <div class="preview form-control" data-preview-content='<%= content %>'></div>
+            <div class="text-center div-btns mt-2">
               <%= f.submit btn_name, class: "btn btn-primary" %>
               <%= link_to 'キャンセル', users_article_path(@article, dashboard: true), class: "btn btn-outline-dark" if btn_name == "更新" %>
             </div>

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -5,21 +5,4 @@ module LoginSupport
     fill_in 'user[password]', with: user.password
     click_button 'ログイン'
   end
-
-  def drop_files files, drop_area_class
-    js_script = "fileList = Array();"
-    # files.count.times do |i|
-      # Generate a fake input selector
-      # page.execute_script("if ($('#seleniumUpload#{i}').length == 0) { seleniumUpload#{i} = window.$('<input/>').attr({id: 'seleniumUpload#{i}', type:'file'}).appendTo('body'); }")
-      page.execute_script("if ($('#seleniumUpload').length == 0) { seleniumUpload = window.$('<input/>').attr({id: 'seleniumUpload', type:'file'}).appendTo('body'); }")
-      # Attach file to the fake input selector through Capybara
-      # attach_file("seleniumUpload#{i}", files[i])
-      attach_file("seleniumUpload", files)
-      # Build up the fake js event
-      js_script = "#{js_script} fileList.push(seleniumUpload.get(0).files[0]);"
-    end
-
-    # Trigger the fake drop event
-    page.execute_script("#{js_script} e = $.Event('drop'); e.originalEvent = {dataTransfer : { files : fileList } }; $('.#{drop_area_class}').trigger(e);")
-  end  
 end


### PR DESCRIPTION
### 概要
記事投稿ページと記事編集ページのタイトルとサブタイトルフォームを上に分離させる実装。

### 実装方法
spec/support/login_support.rbの編集は、bin/testで出るエラーを回避するため。
bin/testでエラーが出るとmergeができないっぽかったので。。。

### 実装画像などあれば添付する
![スクリーンショット 2022-12-17 18 20 58](https://user-images.githubusercontent.com/59328464/208235120-6a2cf02b-ac45-4526-87e5-f58c7061c040.png)
![スクリーンショット 2022-12-17 18 21 22](https://user-images.githubusercontent.com/59328464/208235121-ba131951-e784-4df8-a9b3-b6ad0564b548.png)
![スクリーンショット 2022-12-17 18 46 55](https://user-images.githubusercontent.com/59328464/208236044-1cdbcec1-6b3e-4287-b5a2-ea8e8f8749f4.png)

