### PR TITLE
finish yosei/fix/article_table_split_title_and_subtitle

### DIFF
--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -5,7 +5,8 @@
         <table class="table table-hover articles-table">
           <thead>
             <tr>
-              <th class="px-5">タイトル<span class="span-subtitle">〜サブタイトル〜</span></th>
+              <th class="px-5">タイトル</th>
+              <th class="px-5">サブタイトル</th>
               <% unless dashboard %>
                 <th class="px-5">投稿者</th>
               <% end %>
@@ -16,12 +17,8 @@
             <% if @articles.exists? %>
               <% @articles.each do |a| %>
                 <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                  <td>
-                    <%= a.title %>
-                    <% if a.sub_title.present? %>
-                      <span class="span-subtitle">〜<%= a.sub_title %>〜</span>
-                    <% end %>
-                  </td>
+                  <td><%= a.title %></td>
+                  <td><%= a.sub_title %></td>
                   <% if !dashboard %>
                     <td><%= @users.find(a.user_id).name %></td>
                   <% end %>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -13,7 +13,7 @@
         <h1>
           <%= @article.title %>
         </h1>
-        <h4 class="ml-3">〜<%= @article.sub_title %>〜</h4>
+        <h4 class="ml-3"><%= @article.sub_title %></h4>
       </div>
       <% if @article.user_id != current_user.id %>
         <div class="mt-3">


### PR DESCRIPTION
### 概要
記事一覧と投稿した記事一覧ページの記事テーブルのタイトルとサブタイトルを分ける実装。
記事詳細ページのサブタイトルの’~’を削除。

### 実装画像などあれば添付する
![スクリーンショット 2022-12-17 19 04 45](https://user-images.githubusercontent.com/59328464/208236808-1bde03c7-edb2-4275-af45-ee0cb9146b91.png)
![スクリーンショット 2022-12-17 19 04 54](https://user-images.githubusercontent.com/59328464/208236814-5e9cc171-ae65-47ce-9220-a01eb52923e1.png)
![スクリーンショット 2022-12-17 19 04 30](https://user-images.githubusercontent.com/59328464/208236805-f3136275-76a0-408c-a4e1-fd54b8e661a2.png)

