### PR TITLE
finish articles_table_ellipsis

### DIFF
--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -4,6 +4,7 @@ module Users
   class ArticlesController < Users::Base
     protect_from_forgery
     before_action :set_article, except: %i[index show new create image]
+    before_action :set_dashboard, only: %i[show new create edit update destroy]
 
     def index
       @articles = Article.all.order(updated_at: 'DESC').page(params[:page]).per(30)
@@ -11,7 +12,6 @@ module Users
 
     def show
       @article = Article.find(params[:id])
-      @dashboard = params[:dashboard] == "false" ? false : true
     end
 
     def new
@@ -22,7 +22,7 @@ module Users
       @article = current_user.articles.new(article_params)
       if @article.save
         flash[:notice] = '記事を作成しました。'
-        redirect_to users_article_url(@article)
+        redirect_to users_article_url(@article, dashboard: params[:dashboard], page: params[:page])
       else
         flash.now[:alert] = '記事の作成に失敗しました。'
         render :new
@@ -30,12 +30,13 @@ module Users
     end
 
     def edit
+      @show = params[:show].present?
     end
 
     def update
       if @article.update(article_params)
         flash[:notice] = '記事を編集しました。'
-        redirect_to users_article_url(@article)
+        redirect_to users_article_url(@article, dashboard: params[:dashboard], page: params[:page])
       else
         flash.now[:alert] = '記事の編集に失敗しました。'
         render :edit
@@ -45,11 +46,10 @@ module Users
     def destroy
       flash[:notice] = '記事を削除しました。'
       @article.destroy
-      dashboard = params[:dashboard] == "false" ? false : true
-      if dashboard
-        redirect_to users_dash_boards_path(current_user)
+      if @dashboard
+        redirect_to users_dash_boards_path(current_user, page: params[:page])
       else
-        redirect_to users_articles_path
+        redirect_to users_articles_path(page: params[:page])
       end
     end
 
@@ -69,6 +69,11 @@ module Users
 
     def set_article
       @article = current_user.articles.find(params[:id])
+    end
+
+    def set_dashboard
+      params[:dashboard] ||= "false"
+      @dashboard = params[:dashboard] == "false" ? false : true
     end
   end
 end

--- a/app/views/users/articles/edit.html.erb
+++ b/app/views/users/articles/edit.html.erb
@@ -2,6 +2,6 @@
 <% provide(:title,  "記事編集") %>
 <div class="content">
   <div class="container">
-    <%= render "users/articles/shared/article_form_and_preview", btn_name: "更新", url: users_article_path, method: :patch %>
+    <%= render "users/articles/shared/article_form_and_preview", btn_name: "更新", url: users_article_path(dashboard: @dashboard, page: params[:page]), method: :patch %>
   </div>
 </div>

--- a/app/views/users/articles/new.html.erb
+++ b/app/views/users/articles/new.html.erb
@@ -3,6 +3,6 @@
 <%= image_tag "avatar.png", class: "article-img" %>
 <div class="content">
   <div class="container">
-    <%= render "users/articles/shared/article_form_and_preview", btn_name: "投稿", url: users_articles_path, method: :post %>
+    <%= render "users/articles/shared/article_form_and_preview", btn_name: "投稿", url: users_articles_path(dashboard: @dashboard, page: params[:page]), method: :post %>
   </div>
 </div>

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -32,7 +32,14 @@
             <div class="preview form-control" data-preview-content='<%= content %>'></div>
             <div class="text-center div-btns mt-2">
               <%= f.submit btn_name, class: "btn btn-primary" %>
-              <%= link_to 'キャンセル', users_article_path(@article, dashboard: true), class: "btn btn-outline-dark" if btn_name == "更新" %>
+              <% if btn_name == "更新" && @show %>
+                <%= link_to 'キャンセル', users_article_path(@article, dashboard: @dashboard, page: params[:page]), class: "btn btn-outline-dark" %>
+              <% elsif btn_name == "更新" && !@show %>
+                <%= link_to 'キャンセル', users_dash_boards_path(page: params[:page]), class: "btn btn-outline-dark" if @dashboard %>
+                <%= link_to 'キャンセル', users_articles_path(page: params[:page]), class: "btn btn-outline-dark" unless @dashboard %>
+              <% else %>
+                <%= link_to 'キャンセル', :back, class: "btn btn-outline-dark" if request.referer %>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -11,18 +11,35 @@
                 <th class="px-5">投稿者</th>
               <% end %>
               <th class="px-5">投稿日</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
             <% if @articles.exists? %>
               <% @articles.each do |a| %>
-                <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
+                <tr>
                   <td><%= a.title %></td>
                   <td><%= a.sub_title %></td>
                   <% if !dashboard %>
                     <td><%= a.user.name %></td>
                   <% end %>
                   <td><%= l(a.created_at, format: :long) %></td>
+                  <%# if params[:content] %>
+                  <%# <td rowspan="2" class="align-middle text-center"> %>
+                  <%# else %>
+                  <td>
+                  <%# end %>
+                    <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
+                    <ul class="dropdown-menu">
+                      <% if a.user_id == current_user.id %>
+                        <li><%= link_to '閲覧', users_article_path(id: a.id, dashboard: dashboard, page: params[:page]), class: "nav-link" %></li>
+                        <li><%= link_to '編集', edit_users_article_path(id: a.id, dashboard: dashboard, page: params[:page]), class: "nav-link" %></li>
+                        <li><%= link_to '削除', users_article_path(id: a.id, dashboard: dashboard, page: params[:page]), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
+                      <% else %>
+                        <li><%= link_to '閲覧', users_article_path(id: a.id, dashboard: dashboard, page: params[:page]), class: "nav-link" %></li>
+                      <% end %>
+                    </ul>
+                  </td>
                 </tr>
               <% end %>
             <% else %>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -3,8 +3,8 @@
   <div class="row">
     <% if @article.user_id == current_user.id %>
       <div class="d-flex col-10 justify-content-end">
-        <%= link_to "編集", edit_users_article_path, class: "btn btn-success" %>
-        <%= link_to "削除", users_article_path(dashboard: @dashboard), method: :delete, data: {confirm: "表示中の記事を削除します。"}, class: "btn btn-danger ml-2" %>
+        <%= link_to "編集", edit_users_article_path(dashboard: @dashboard, page: params[:page], show: true), class: "btn btn-success" %>
+        <%= link_to "削除", users_article_path(dashboard: @dashboard, page: params[:page]), method: :delete, data: {confirm: "表示中の記事を削除します。"}, class: "btn btn-danger ml-2" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
### 概要
一般画面の記事テーブルに3点リーダーを追加。

### 実装内容・手法
菅原さん?のコピペ。
https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=754333106

### 実装画像
![スクリーンショット 2023-01-14 14 02 59](https://user-images.githubusercontent.com/59328464/212456811-865c4784-c32f-4d2a-ad7b-5f2b84ba1eb0.png)
![スクリーンショット 2023-01-14 14 03 27](https://user-images.githubusercontent.com/59328464/212456814-2ac26226-8547-434f-8a7a-c346d454f91a.png)
![スクリーンショット 2023-01-14 14 03 11](https://user-images.githubusercontent.com/59328464/212456819-a40722e6-d99e-40a9-9314-05e4c95c08b9.png)