### PR TITLE
Yosei/fix/article new page

### DIFF
--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -6,12 +6,14 @@ $(function(){
   var m_editor = $(".markdown-editor");
   var preview = $(".preview");
   preview.height(m_editor.height());
-  preview.css('color', m_editor.css('color'));
+  console.log(m_editor.css('color'))
+  preview.css('color', "#212529");
   preview.html(preview.data("preview-content"));
   $('.editor-side .card').height($('.preview-side .card').height())
   
   if($(".markdown-editor").val()){
     var content = $(".markdown-editor").text()
+    content ||= ''
     content = mathtodollars(content);
     content = marked(content)
     var elem = $('.preview')
@@ -24,15 +26,15 @@ $(function(){
       $(this).width("60%")
       $(this).height("60%")
     })
-  }else{
-    $('.preview').html("コンテンツ");
   }
 
   $('.markdown-editor').keyup(function(event){
     var content = $(this).val()
-    content ||= "コンテンツ"
+    // content ||= "コンテンツ"
+    content ||= preview.data("preview-content")
     content = marked(content);
-    content ||= "コンテンツ"
+    // content ||= "コンテンツ"
+    content ||= preview.data("preview-content")
     var pre = $('.preview')
     pre.html(content);
     pre.find("img").each(function(){
@@ -52,8 +54,6 @@ $(function(){
     var formData = new FormData();
     formData.append('image', image); // FormDataに画像を追加
     formData.append('user_id', e.target.dataset.userId); // FormDataに画像を追加
-    console.log(e)
-    console.log(image)
 
     // ajaxで画像をアップロード
     $.ajax({

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -6,8 +6,6 @@ $(function(){
   var m_editor = $(".markdown-editor");
   var preview = $(".preview");
   preview.height(m_editor.height());
-  console.log(m_editor.css('color'))
-  preview.css('color', "#212529");
   preview.html(preview.data("preview-content"));
   $('.editor-side .card').height($('.preview-side .card').height())
   
@@ -30,10 +28,8 @@ $(function(){
 
   $('.markdown-editor').keyup(function(event){
     var content = $(this).val()
-    // content ||= "コンテンツ"
     content ||= preview.data("preview-content")
     content = marked(content);
-    // content ||= "コンテンツ"
     content ||= preview.data("preview-content")
     var pre = $('.preview')
     pre.html(content);

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -1,8 +1,4 @@
 //以下new
-.div-btns {
-  bottom: 8%;
-}
-
 .preview {
   overflow: scroll;
 }

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -1,7 +1,6 @@
 //以下new
 .div-btns {
-  position: sticky;
-  bottom: 10%;
+  bottom: 8%;
 }
 
 .preview {

--- a/app/views/users/articles/new.html.erb
+++ b/app/views/users/articles/new.html.erb
@@ -1,6 +1,5 @@
 <%= javascript_pack_tag "users/articles_new_and_edit" %>
 <% provide(:title,  "記事投稿") %>
-<%= image_tag "avatar.png", class: "article-img" %>
 <div class="content">
   <div class="container">
     <%= render "users/articles/shared/article_form_and_preview", btn_name: "投稿", url: users_articles_path(dashboard: @dashboard, page: params[:page]), method: :post %>

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -28,7 +28,7 @@
         </div>
         <div class="card-body col-12">
           <div class="sticky">
-            <% content = @article.content ? simple_format(@article.content) : "コンテンツ" %>
+            <% content = @article.content ? simple_format(@article.content) : "" %>
             <div class="preview form-control" data-preview-content='<%= content %>'></div>
             <div class="text-center div-btns mt-2">
               <%= f.submit btn_name, class: "btn btn-primary" %>

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -30,7 +30,7 @@
           <div class="sticky">
             <% content = @article.content ? simple_format(@article.content) : "" %>
             <div class="preview form-control" data-preview-content='<%= content %>'></div>
-            <div class="text-center div-btns mt-2">
+            <div class="text-center div-btns mt-3">
               <%= f.submit btn_name, class: "btn btn-primary" %>
               <% if btn_name == "更新" && @show %>
                 <%= link_to 'キャンセル', users_article_path(@article, dashboard: @dashboard, page: params[:page]), class: "btn btn-outline-dark" %>


### PR DESCRIPTION
### 概要
新規記事投稿ページの投稿＆キャンセルボタンがスクロールするバグの修正。
ついでに同ページに表示していたアバター画像を削除。
また、プレビュー表示側のプレイスホルダーを削除。

### 実装画像などあれば添付する
![スクリーンショット 2023-01-24 20 10 00](https://user-images.githubusercontent.com/59328464/214277429-89f263e7-1253-4a7d-bf36-677bfd4fc00c.png)
![スクリーンショット 2023-01-24 20 10 10](https://user-images.githubusercontent.com/59328464/214277459-a37f8aaa-61dd-4b30-a2ce-6ac00a02480f.png)
![スクリーンショット 2023-01-24 20 10 22](https://user-images.githubusercontent.com/59328464/214277492-d571ab9a-a21a-47c7-8813-c42a3a024839.png)