### PR TITLE
つぶやき機能に機能追加

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -42,6 +42,11 @@ module Users
       end
     end
 
+    def index_user
+      @tweets = Tweet.where(user_id: params[:id])
+      @user = User.find(params[:id])
+    end
+
     private
       
     def tweet_params

--- a/app/views/layouts/users/_header.html.erb
+++ b/app/views/layouts/users/_header.html.erb
@@ -30,7 +30,7 @@
               <p>動画投稿</p>
             <% end %>
           </li>
-        <% elsif request.fullpath == "/users/tweets" %>
+        <% elsif request.fullpath.include?("/users/tweets") %>
           <li class="nav-item">
             <%= link_to new_users_tweet_path, class: "nav-link", remote: true, method: :get do %>
               <p>つぶやき投稿</p>

--- a/app/views/users/tweets/index_user.html.erb
+++ b/app/views/users/tweets/index_user.html.erb
@@ -1,0 +1,5 @@
+<%= javascript_pack_tag "users/index_articles_and_dashboards" %>
+<% provide(:title,  "#{@user.name}のつぶやき一覧") %>
+<%= render "users/tweets/shared/tweets_table", dashboard: false %>
+<div id="new" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
+<div id="edit" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -4,8 +4,12 @@
       <% @tweets.each do |tweet| %>
         <div class="tweets-index-item">
           <div class="fw-bold">
-            <%= tweet.user.name %>
-              <span style="margin-right: 1em;"></span>
+            <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+            <%= image_tag image , class: "rounded-circle", size: "30x30" %><b class="caret"></b>          
+            <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
+              <%= tweet.user.name %>
+            <% end %>
+            <span style="margin-right: 1em;"></span>
             <%= tweet.created_at.strftime("%Y年%m月%d日").to_s %>
           </div>
         </div>
@@ -19,6 +23,7 @@
                 <span style="margin-right: 1em;"></span>
                 <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>
                 <ul class="dropdown-menu">
+                  <li><%= link_to '詳細', index_user_users_tweet_path(tweet.user_id), class:"dropdown-item" %></li>
                   <% if tweet.user.name == current_user.name %>
                     <li><%= link_to '編集', edit_users_tweet_path(tweet), remote: true, class:"dropdown-item" %></li>
                     <li><%= link_to '削除', users_tweet_path(tweet), method: :delete, data: { confirm: 'Are you sure?' }, class:"dropdown-item" %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,11 @@ Rails.application.routes.draw do
     resources :users, only: [:index]
     end
     resources :profiles
-    resources :tweets #つぶやき機能
+    resources :tweets do #つぶやき機能
+      member do
+        get 'index_user'
+      end
+    end
   end
   # =================================================================
 


### PR DESCRIPTION
### 概要

- _各ユーザーのつぶやき一覧画面を追加_
- _3点リーダーに詳細を追加_
### タスク
- [] なし
- [x] あり _https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=29885647_

### 実装内容・手法

- _つぶやき一覧のユーザー名押下でそのユーザーのつぶやき一覧画面に遷移する。_
- _current_userの投稿のみ編集・削除が可能。_
- _つぶやき一覧の3点リーダーに「詳細」を追加。詳細を押下すると、そのユーザーのつぶやき一覧画面に遷移する。_

### 実装画像などあれば添付する

https://docs.google.com/spreadsheets/d/1qKQoSdS0U2xI-M8FDzD1PRNTOG8uA6E_scCHxaEQpwE/edit#gid=0


