### PR TITLE
Yosei/fix/article show image backgroundcolor

### DIFF
--- a/app/javascript/packs/users/articles.js
+++ b/app/javascript/packs/users/articles.js
@@ -3,10 +3,6 @@ import "highlight.js/scss/github-dark.scss";
 import { marked } from 'marked'
 import '../../stylesheets/users/articles'
 
-$(function(){
-  $(".hr").css({"color": "$gray-400"})
-})
-
 marked.setOptions({
   highlight: function (code, lang) {
     if(lang && lang.indexOf(":") >= 0){
@@ -60,12 +56,11 @@ window.mathtodollars = function(content){
 window.resize_img = function(parent){
   parent.find("img").each(function(){
     $(this).bind("load", function(){
-      var w = $(this).width()
-      var h = $(this).height()
-      if(w >= h){
-        $(this).width("250")
+      var parent_wide = $(this).parent().width()
+      if($(this).width() >= $(this).height()){
+        $(this).width(parent_wide)
       }else{
-        $(this).height("250")
+        $(this).height(parent_wide)
       }
     })
   })

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -11,40 +11,49 @@ $(function(){
   
   if($(".markdown-editor").val()){
     var content = $(".markdown-editor").text()
-    content ||= ''
-    content = mathtodollars(content);
-    content = marked(content)
-    var elem = $('.preview')
-    elem.html(content);
-    var pre = elem.find('pre');
+    if($.type(content) == "string"){
+      content = mathtodollars(content);
+      content = marked(content)
+    }
+    // content ||= ''
+    // content = mathtodollars(content);
+    // content = marked(content)
+    var preview = $('.preview')
+    preview.html(content);
+    var pre = preview.find('pre');
     pre.each(function(){
       makecodeblock($(this))
     })
-    elem.find("img").each(function(){
-      $(this).width("60%")
-      $(this).height("60%")
-    })
+    // preview.find("img").each(function(){
+    //   $(this).width("100%")
+    //   $(this).height("60%")
+    // })
+    resize_img(preview)
   }
 
   $('.markdown-editor').keyup(function(event){
     var content = $(this).val()
-    content ||= preview.data("preview-content")
-    content = marked(content);
-    content ||= preview.data("preview-content")
-    var pre = $('.preview')
-    pre.html(content);
-    pre.find("img").each(function(){
-      $(this).width("60%")
-      $(this).height("60%")
-    })
-    pre = pre.find('pre');
-    pre.each(function(){
+    if($.type(content) == "string"){
+      content = mathtodollars(content);
+      content = marked(content)
+    }
+    // content ||= preview.data("preview-content")
+    // content = marked(content);
+    // content ||= preview.data("preview-content")
+    var preview = $('.preview')
+    preview.html(content);
+    // preview.find("img").each(function(){
+    //   $(this).width("100%")
+    //   $(this).height("100%")
+    // })
+    preview = preview.find('pre');
+    preview.each(function(){
       makecodeblock($(this))
     })
+    resize_img(preview)
   });
   
   $('.markdown-editor').on('drop', function(e) { //dropのイベントをハンドル
-    console.warn('a')
     e.preventDefault(); //元の動きを止める処理
     var image = e.originalEvent.dataTransfer.files[0]; //ドロップされた画像の1件目を取得
     var formData = new FormData();

--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -3,8 +3,6 @@ import "./articles"
 
 $(function(){
 
-  $('.hr').css({'width': '90%', 'margin-left': '4rem'})
-
   if($(".article-content").length){
     var article = $(".article-content")
     var content = article.data("article")
@@ -13,7 +11,7 @@ $(function(){
       content = marked(content)
     }
     article.html(content);
-    MathJax.Hub.Typeset(["Typeset",MathJax.Hub, "posts-preview"]); 
+    // MathJax.Hub.Typeset(["Typeset",MathJax.Hub, "posts-preview"]); 
     var pre = article.find("pre")
     pre.each(function(){
       makecodeblock($(this))
@@ -22,6 +20,20 @@ $(function(){
     })
     resize_img(article)
   }
+
+  $(window).on('load', function () {
+    $(".article-content").find("img").each(function(){
+      $(this).wrap('<a href="" class="zoomin-img" data-bs-toggle="modal" data-bs-target="#zoominImgModal"></a>')
+    })
+
+    $('.zoomin-img').on('click', function(){
+      var img = $('.zoomin-modal').children()
+      if(img.length){
+        img.remove()
+      }
+      $('.zoomin-modal').append($(this).children('img').clone())
+    })
+  });
 
   $(".code-copy__button").click(function(){
     var codecopy = $(this).parent(".code-copy")

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -3,6 +3,13 @@
   overflow: scroll;
 }
 
+//show
+.article-show {
+  background-color: white;
+  border: 1px solid blue;
+  border-radius: 5px;
+}
+
 //以下index
 .articles-table {
   tr td {
@@ -15,10 +22,3 @@
     font-size: small;
   }
 }
-
-//共通(show&index&dashboard)
-.hr {
-  border: 1px solid #adb5bd;
-  margin: 10px 0;
-}
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,2 @@
 <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 <%= content_for?(:content) ? yield(:content) : yield %>
-
-
-<!-- ドロップダウンリストを開くためのスクリプト -->
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>

--- a/app/views/layouts/users.html.erb
+++ b/app/views/layouts/users.html.erb
@@ -8,7 +8,8 @@
 
     <%= stylesheet_pack_tag 'users', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'users', 'data-turbolinks-track': 'reload' %>
-    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+    <%# <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script> %>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
         tex2jax: {
@@ -17,7 +18,7 @@
         }
       });
     </script>
-    <script src="http://andywer.github.io/drag-mock/drag-mock.min.js"></script>     
+    <%# <script src="http://andywer.github.io/drag-mock/drag-mock.min.js"></script>      %>
   </head>
 
   <body class="hold-transition sidebar-mini" id="<%= page_body_id(params) %>">

--- a/app/views/layouts/users/_header.html.erb
+++ b/app/views/layouts/users/_header.html.erb
@@ -1,3 +1,8 @@
+<!-- ドロップダウンリストを開くためのスクリプト -->
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+
 <!-- Navbar -->
 <nav class="main-header navbar navbar-expand navbar-white navbar-light">
   <!-- Left navbar links -->

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -13,7 +13,7 @@
           <h3 class="card-title text-center">エディター</h3>
         </div>
         <div class="card-body">
-          <div class="col-12 div-textarea">
+          <div class="col-12">
             <%= f.text_area :content, placeholder: "コンテンツ", cols: 30, rows: 100,
              class: "form-control markdown-editor", data: {user_id: current_user.id} %>
           </div>
@@ -29,7 +29,7 @@
         <div class="card-body col-12">
           <div class="sticky">
             <% content = @article.content ? simple_format(@article.content) : "" %>
-            <div class="preview form-control" data-preview-content='<%= content %>'></div>
+            <div class="preview form-control" cols="30" rows="100" data-preview-content='<%= content %>'></div>
             <div class="text-center div-btns mt-3">
               <%= f.submit btn_name, class: "btn btn-primary" %>
               <% if btn_name == "更新" && @show %>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -1,36 +1,45 @@
+<%# <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script> %>
 <%= javascript_pack_tag "users/articles_show" %>
 <div class="container">
   <div class="row">
-    <% if @article.user_id == current_user.id %>
-      <div class="d-flex col-10 justify-content-end">
-        <%= link_to "編集", edit_users_article_path(dashboard: @dashboard, page: params[:page], show: true), class: "btn btn-success" %>
-        <%= link_to "削除", users_article_path(dashboard: @dashboard, page: params[:page]), method: :delete, data: {confirm: "表示中の記事を削除します。"}, class: "btn btn-danger ml-2" %>
-      </div>
-    <% end %>
-
-    <div class="col-10">
-      <div class="col-9 offset-2 float-left mb-1 text-left">
-        <h1>
-          <%= @article.title %>
-        </h1>
-        <h4 class="ml-3"><%= @article.sub_title %></h4>
-      </div>
-      <% if @article.user_id != current_user.id %>
-        <div class="mt-3">
-          投稿者：<%= User.find(@article.user_id).name %>
+    <div class="offset-1 col-10 article-show">
+      <div class="col-12 d-flex justify-content-between">
+        <div class="ml-4 mt-4">
+          <h1><%= @article.title %></h1>
+          <h4 class="ml-5"><%= @article.sub_title %></h4>
         </div>
-      <% end %>
-    </div>
-    <div class="hr"></div>
-    <div class="col-10 offset-1 article-content" data-article="<%= @article.content %>"></div>
-
-    <div class="code-copy" style="display: none;">
-      <div class="code-copy__message" style="display: none;">
-        Copied!
+        <div class="m-5 mb-4">
+          <% if @article.user == current_user %>
+            <%= link_to "編集", edit_users_article_path(dashboard: @dashboard, page: params[:page], show: true), class: "btn btn-success" %>
+            <%= link_to "削除", users_article_path(dashboard: @dashboard, page: params[:page]), method: :delete, data: {confirm: "表示中の記事を削除します。"}, class: "btn btn-danger ml-2" %>
+          <% else %>
+            投稿者：<%= User.find(@article.user_id).name %>
+          <% end %>
+        </div>
       </div>
-      <button class="code-copy__button" style="display: none;">
-        <span class="fa fa-fw fa-clipboard"></span>
-      </button>
+      <hr>
+      <div class="m-4 article-content" data-article="<%= @article.content %>"></div>
+
+      <div class="code-copy" style="display: none;">
+        <div class="code-copy__message" style="display: none;">
+          Copied!
+        </div>
+        <button class="code-copy__button" style="display: none;">
+          <span class="fa fa-fw fa-clipboard"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="zoominImgModal" tabindex="-1" aria-labelledby="zoominImgModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <button type="button" class="text-right modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
+      <div class="modal-body text-center align-middle">
+        <div class="zoomin-modal">
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### 概要
記事内の画像サイズの調整。
記事詳細に背景を追加。
ドロップダウンのためのscriptタグを別ページに移動。
コードの簡略化(タイトル群と内容を分ける線)。
mathjaxとマークダウンに関連したjsエラー対応のためのコード修正。

### 実装画像などあれば添付する
![スクリーンショット 2023-01-27 16 37 58](https://user-images.githubusercontent.com/59328464/215237545-f4d6e388-bd7e-44e3-9642-303f75fdf437.png)
![スクリーンショット 2023-01-28 11 56 20](https://user-images.githubusercontent.com/59328464/215238602-e8fe0b3a-2133-4a0d-94a4-94cd3299d621.png)
