### PR TITLE
finish fix/article_new_preview

### DIFF
--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -3,10 +3,9 @@ import "./articles"
 
 $(function(){
   
-  var m_editor = $(".markdown-editor");
+  var editor = $(".markdown-editor");
   var preview = $(".preview");
-  preview.height(m_editor.height());
-  preview.html(preview.data("preview-content"));
+  preview.height(editor.height());
   $('.editor-side .card').height($('.preview-side .card').height())
   
   if($(".markdown-editor").val()){
@@ -15,19 +14,12 @@ $(function(){
       content = mathtodollars(content);
       content = marked(content)
     }
-    // content ||= ''
-    // content = mathtodollars(content);
-    // content = marked(content)
     var preview = $('.preview')
     preview.html(content);
     var pre = preview.find('pre');
     pre.each(function(){
       makecodeblock($(this))
     })
-    // preview.find("img").each(function(){
-    //   $(this).width("100%")
-    //   $(this).height("60%")
-    // })
     resize_img(preview)
   }
 
@@ -37,15 +29,8 @@ $(function(){
       content = mathtodollars(content);
       content = marked(content)
     }
-    // content ||= preview.data("preview-content")
-    // content = marked(content);
-    // content ||= preview.data("preview-content")
     var preview = $('.preview')
     preview.html(content);
-    // preview.find("img").each(function(){
-    //   $(this).width("100%")
-    //   $(this).height("100%")
-    // })
     preview = preview.find('pre');
     preview.each(function(){
       makecodeblock($(this))
@@ -71,6 +56,7 @@ $(function(){
     })
     .done(function(data, textStatus, jqXHR){
       setImage(data['name'], data['url'])
+      resize_img($(".preview"))
     })
     .fail(function(jqXHR, textStatus, errorThrown){
       alert("画像の挿入に失敗しました。");
@@ -90,7 +76,6 @@ $(function(){
     textarea.value = sentence;
     var content = marked(textarea.value)
     $(".preview").html(content);
-    resize_img($(".preview"))
   }
 
 });

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -1,8 +1,3 @@
-//以下new
-.preview {
-  overflow: scroll;
-}
-
 //show
 .article-show {
   background-color: white;

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,8 +4,8 @@ class Article < ApplicationRecord
   mount_uploader :image, ImageUploader # ようせい追加（画像保存）
 
   belongs_to :user
-  validates :title, presence: true, length: { in: 1..20 }
-  validates :sub_title, allow_nil: true, length: { in: 1..40 }
+  validates :title, presence: true, length: { in: 1..40 }
+  validates :sub_title, allow_nil: true, length: { maximum: 50 }
   validates :content, presence: true
 
   def self.sort_filter(filter)

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -27,20 +27,18 @@
           <h3 class="card-title">プレビュー</h3>
         </div>
         <div class="card-body col-12">
-          <div class="sticky">
-            <% content = @article.content ? simple_format(@article.content) : "" %>
-            <div class="preview form-control" data-preview-content='<%= content %>'></div>
-            <div class="text-center div-btns mt-3">
-              <%= f.submit btn_name, class: "btn btn-primary" %>
-              <% if btn_name == "更新" && @show %>
-                <%= link_to 'キャンセル', users_article_path(@article, dashboard: @dashboard, page: params[:page]), class: "btn btn-outline-dark" %>
-              <% elsif btn_name == "更新" && !@show %>
-                <%= link_to 'キャンセル', users_dash_boards_path(page: params[:page]), class: "btn btn-outline-dark" if @dashboard %>
-                <%= link_to 'キャンセル', users_articles_path(page: params[:page]), class: "btn btn-outline-dark" unless @dashboard %>
-              <% else %>
-                <%= link_to 'キャンセル', :back, class: "btn btn-outline-dark" if request.referer %>
-              <% end %>
-            </div>
+          <% content = @article.content ? @article.content : "" %>
+          <div class="preview form-control" style="overflow: scroll;"></div>
+          <div class="text-center div-btns mt-3">
+            <%= f.submit btn_name, class: "btn btn-primary" %>
+            <% if btn_name == "更新" && @show %>
+              <%= link_to 'キャンセル', users_article_path(@article, dashboard: @dashboard, page: params[:page]), class: "btn btn-outline-dark" %>
+            <% elsif btn_name == "更新" && !@show %>
+              <%= link_to 'キャンセル', users_dash_boards_path(page: params[:page]), class: "btn btn-outline-dark" if @dashboard %>
+              <%= link_to 'キャンセル', users_articles_path(page: params[:page]), class: "btn btn-outline-dark" unless @dashboard %>
+            <% else %>
+              <%= link_to 'キャンセル', :back, class: "btn btn-outline-dark" if request.referer %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -1,20 +1,22 @@
-<%# <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script> %>
+<script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 <%= javascript_pack_tag "users/articles_show" %>
 <div class="container">
   <div class="row">
     <div class="offset-1 col-10 article-show">
-      <div class="col-12 d-flex justify-content-between">
-        <div class="ml-4 mt-4">
+      <div class="col-12">
+        <div class="mx-2 mt-4 mb-3">
           <h1><%= @article.title %></h1>
-          <h4 class="ml-5"><%= @article.sub_title %></h4>
         </div>
-        <div class="m-5 mb-4">
-          <% if @article.user == current_user %>
-            <%= link_to "編集", edit_users_article_path(dashboard: @dashboard, page: params[:page], show: true), class: "btn btn-success" %>
-            <%= link_to "削除", users_article_path(dashboard: @dashboard, page: params[:page]), method: :delete, data: {confirm: "表示中の記事を削除します。"}, class: "btn btn-danger ml-2" %>
-          <% else %>
-            <%= Article.human_attribute_name(:user) %>：<%= @article.user.name %>
-          <% end %>
+        <div class="d-flex justify-content-between">
+          <h4 class="ml-5"><%= @article.sub_title %></h4>
+          <div>
+            <% if @article.user == current_user %>
+              <%= link_to "編集", edit_users_article_path(dashboard: @dashboard, page: params[:page], show: true), class: "btn btn-success" %>
+              <%= link_to "削除", users_article_path(dashboard: @dashboard, page: params[:page]), method: :delete, data: {confirm: "表示中の記事を削除します。"}, class: "btn btn-danger ml-1" %>
+            <% else %>
+              <%= Article.human_attribute_name(:user) %>：<%= @article.user.name %>
+            <% end %>
+          </div>
         </div>
       </div>
       <hr>


### PR DESCRIPTION
# 概要
記事投稿ページにてプレビュー側がスクロール表示されず、エリアからはみ出て表示されるバグの修正。
また、同ページにて、大きい画像を貼り付けると、こちらもエリアからはみ出るバグの修正。
そして、編集&削除ボタンの表示位置修正。
さらに、サブタイトルのバリデーションをallow_nil: trueとしながらも、length: {in: 1..50}としているせいで、nilで登録できない問題を修正。

# 実装動画
https://user-images.githubusercontent.com/59328464/216325337-0cd9728a-881d-4a57-9663-481fb54d454f.mov

