### PR TITLE
Yosei/feat/user/article/show/zoomin img

### DIFF
--- a/app/javascript/packs/users/articles.js
+++ b/app/javascript/packs/users/articles.js
@@ -58,9 +58,9 @@ window.resize_img = function(parent){
     $(this).bind("load", function(){
       var parent_wide = $(this).parent().width()
       if($(this).width() >= $(this).height()){
-        $(this).width(parent_wide)
+        $(this).width() > parent_wide ? $(this).width(parent_wide) : $(this).width()
       }else{
-        $(this).height(parent_wide)
+        $(this).height() > parent_wide ? $(this).height(parent_wide) : $(this).height()
       }
     })
   })

--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -11,7 +11,6 @@ $(function(){
       content = marked(content)
     }
     article.html(content);
-    // MathJax.Hub.Typeset(["Typeset",MathJax.Hub, "posts-preview"]); 
     var pre = article.find("pre")
     pre.each(function(){
       makecodeblock($(this))
@@ -31,7 +30,8 @@ $(function(){
       if(img.length){
         img.remove()
       }
-      $('.zoomin-modal').append($(this).children('img').clone())
+      var src = $(this).children('img').attr('src') 
+      $('.zoomin-modal').append('<img src="' + src + '" width="100%" height="100%">')
     })
   });
 

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -35,7 +35,9 @@
 <div class="modal fade" id="zoominImgModal" tabindex="-1" aria-labelledby="zoominImgModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
-      <button type="button" class="text-right modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
+      <div class="text-right mt-3">
+        <button type="button" class="modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
       <div class="modal-body text-center align-middle">
         <div class="zoomin-modal"></div>
       </div>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -1,4 +1,4 @@
-<%# <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script> %>
+<script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 <%= javascript_pack_tag "users/articles_show" %>
 <div class="container">
   <div class="row">
@@ -20,7 +20,6 @@
       <hr>
       <div class="m-4 article-content" data-article="<%= @article.content %>"></div>
 
-
       <div class="code-copy" style="display: none;">
         <div class="code-copy__message" style="display: none;">
           Copied!
@@ -34,12 +33,11 @@
 </div>
 
 <div class="modal fade" id="zoominImgModal" tabindex="-1" aria-labelledby="zoominImgModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <button type="button" class="text-right modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
       <div class="modal-body text-center align-middle">
-        <div class="zoomin-modal">
-        </div>
+        <div class="zoomin-modal"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# 概要
記事詳細ページにて画像クリックで拡大画像（モーダル）を表示する機能追加。
また添付画像のリサイズに関して、画像幅が枠を超過する場合のみ縮小する設定に変更。

# 実装動画
https://user-images.githubusercontent.com/59328464/217982114-2e15babd-c6b0-4c17-b1b0-6f9513449588.mov



