### PR TITLE
Yosei/bug/article/index/ellipsis

### DIFF
--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -9,7 +9,7 @@
   tr td {
     padding-left: 2rem;
   }
-  .link-tr:hover {
+  .link-td:hover {
     cursor: pointer;
   }
 }

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -12,7 +12,4 @@
   .link-tr:hover {
     cursor: pointer;
   }
-  .span-subtitle {
-    font-size: small;
-  }
 }

--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -28,14 +28,14 @@
           <tbody>
             <% if hover.present? %>
               <% @articles.each_with_index do |a, i| %>
-                <tr class="link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                  <td><%= a.title %></td>
-                  <td><%= a.sub_title %></td>
+                <tr>
+                  <td class="link-td" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'><%= a.title %></td>
+                  <td class="link-td" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'><%= a.sub_title %></td>
                   <% if !dashboard %>
-                    <td><%= a.user.name %></td>
+                    <td class="link-td" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'><%= a.user.name %></td>
                   <% end %>
-                  <td><%= l(a.created_at, format: :long) %></td>
-                  <td onclick='window.location="#"'>
+                  <td class="link-td" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'><%= l(a.created_at, format: :long) %></td>
+                  <td>
                     <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                     <ul class="dropdown-menu">
                       <% if a.user_id == current_user.id %>

--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -35,11 +35,7 @@
                     <td><%= a.user.name %></td>
                   <% end %>
                   <td><%= l(a.created_at, format: :long) %></td>
-                  <%# if params[:content] %>
-                  <%# <td rowspan="2" class="align-middle text-center"> %>
-                  <%# else %>
-                  <td>
-                  <%# end %>
+                  <td onclick='window.location="#"'>
                     <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                     <ul class="dropdown-menu">
                       <% if a.user_id == current_user.id %>
@@ -52,18 +48,6 @@
                     </ul>
                   </td>
                 </tr>
-<%
-=begin
-%>
-テーブルにコンテンツを表示する際にコメント解除
-                <% if params[:content] %>
-                  <tr class="content-tr link-tr" onclick='window.location="<%= users_article_path(id: a.id, dashboard: dashboard) %>"'>
-                    <td class="px-5" colspan="4"><%= a.content %></td>
-                  </tr>
-                <% end %>
-<%
-=end
-%>                
               <% end %>
             <% else %>
               <%= render 'users/shared/table_without_record' %>


### PR DESCRIPTION
# 概要
記事一覧、投稿した記事一覧の3点リーダー押下で、記事詳細ページに遷移してしまうバグの修正。
不要なコメントアウトの削除。

# 実装動画
## before
https://user-images.githubusercontent.com/59328464/219541760-548e6641-6f52-41b1-a3ac-d7be212f37cc.mov

## after
https://user-images.githubusercontent.com/59328464/219549333-74d0f49a-0626-46cb-b5ad-3b2f8b0f6728.mov

