### PR TITLE
bugfix/tweet-and-comment-datetime

### DIFF
--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -15,7 +15,7 @@
                     <% end %>
                   </td>
                   <td style="padding-left: 20px;">
-                    <%= tweet.created_at.strftime("%Y年%m月%d日").to_s %>
+                    <%= tweet.created_at.strftime("%Y年%m月%d日 %H:%M").to_s %>
                   </td>
                 </tr>
               </tbody>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -7,7 +7,7 @@
         <%= @tweet.user.name %>
       </div>
       <div class="col mt-4">
-        <%= l(@tweet.user.created_at, format: :long) %>
+        <%= l(@tweet.created_at, format: :long) %>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
### つぶやき詳細画面のつぶやき投稿時間を修正
- 併せてつぶやき投稿一覧画面の投稿日を投稿日時表示に変更。

- 修正前の画面はこちら
https://trello.com/c/sb5bnAkQ

- 修正後の画面
![スクリーンショット 2023-03-07 11 07 20（2）](https://user-images.githubusercontent.com/99413634/223302853-d467a0c0-2090-4535-bcd7-02f0eaf25841.png)
![スクリーンショット 2023-03-07 11 09 38（2）](https://user-images.githubusercontent.com/99413634/223302900-bfc24e70-2236-4cd2-a5af-8243daa8414b.png)
