### PR TITLE
Feature/comment notification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_comment_notifiations
 
   def after_sign_in_path_for(resource)
     case resource
@@ -18,5 +19,15 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
     devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
+  end
+
+  private
+  # コメント通知件数を表示するためのメソッド
+  def set_comment_notifiations
+    if user_signed_in?
+      @comment_notifications = Comment.where(confirmed: false, recipient_id: current_user.id)
+                                      .where.not(user_id: current_user.id) #user_idがログインユーザーの場合はカウントしない。
+                                      .order(created_at: :desc)
+    end
   end
 end

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -35,10 +35,18 @@ module Users
       redirect_to users_tweet_path(@tweet)
     end
 
+    # 未確認の通知を確認するアクション
+    def confirmed_notification
+      @tweet = Tweet.find(params[:tweet_id])
+      @tweet.comments.where(confirmed: false, recipient_id: current_user.id).update_all(confirmed: true)
+      redirect_to users_tweet_path(@tweet)
+    end
+    
+
     private
 
     def comment_params
-      params.require(:comment).permit(:comment_content, :tweet_id)  #formにてtweet_idパラメータを送信して、コメントへtweet_idを格納するようにする必要がある。
+      params.require(:comment).permit(:comment_content, :tweet_id, :recipient_id, :confirmed)  #formにてtweet_idパラメータを送信して、コメントへtweet_idを格納するようにする必要がある。
     end
   end
 end

--- a/app/javascript/packs/users/tweets.js
+++ b/app/javascript/packs/users/tweets.js
@@ -40,3 +40,16 @@ const updateTimestamps = () => {
 document.addEventListener('DOMContentLoaded', () => {
   setInterval(updateTimestamps, 1000); // 1秒ごとに更新する
 });
+
+// notification-linkクラスを持つリンクがクリックされたときにフォームが送信される
+document.addEventListener('DOMContentLoaded', () => {
+  const notificationLinks = document.querySelectorAll('.notification-link');
+
+  notificationLinks.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      const form = link.closest('.notification-form');
+      form.submit();
+    });
+  });
+});

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -16,10 +16,52 @@
 
 .comment-submit {
   margin-top: 5px;
-  // margin-bottom: 20px;
 }
 
 .form-group textarea {
   height: 200px;
   max-width: 800px;
+}
+
+// bootstrap5のモーダル
+.modal {
+  z-index: 2000;
+}
+
+.modal-dialog-slideout {
+  max-width: 750px;
+  position: fixed;
+  top: -25px;// 上側の位置を調整
+  // right: 0;
+  bottom: 0;
+  left: 250px;//サイドバーの右側に表示
+  z-index: 1050;
+  overflow: hidden;
+  outline: 0;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-out;
+}
+
+.modal.fade .modal-dialog-slideout {
+  transform: translateX(-100%);
+}
+
+.modal.show .modal-dialog-slideout {
+  transform: translateX(0);
+}
+
+.modal-backdrop {
+  z-index: 1000;
+}
+
+// コメント通知一覧のモーダル内のクラス 
+.notification-link {
+  text-decoration: none;
+  color: black;
+}
+
+.notification-link:hover {
+  text-decoration: none;
+  color: black;
+  background-color: #d1c5c5;
 }

--- a/app/views/layouts/users/_side.html.erb
+++ b/app/views/layouts/users/_side.html.erb
@@ -38,6 +38,9 @@
             <i class="nav-icon fa-brands fa-twitter"></i> 
             <p>
               つぶやき一覧
+              <% if @comment_notifications.count > 0 %>
+                <span class="badge rounded-pill badge-success"><%= @comment_notifications.count %></span> <%# コメント通知件数をバッジ通知する %>
+              <% end %>
             </p>
           <% end %>
         </li>

--- a/app/views/users/tweets/index.html.erb
+++ b/app/views/users/tweets/index.html.erb
@@ -2,22 +2,33 @@
 <% provide(:title, "つぶやき一覧") %>
 <% number_of_comment_notifications = @comment_notifications.count %>
 <% if number_of_comment_notifications > 0 %>
-  <span class="dropdown">
-  <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown">
-  <%= number_of_comment_notifications %>件のコメント通知があります。
+  <!-- モーダルのトリガー -->
+  <a href="#" data-bs-toggle="modal" data-bs-target="#commentNotificationModal">
+    <%= number_of_comment_notifications %>件のコメント通知があります。
   </a>
-    <ul class="dropdown-menu">
-      <% @comment_notifications.each do |notification| %>
-        <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true do |form| %>
-          <li>
-            <strong><%= notification.user.name %>さんからのコメント</strong>
-            <p><%= form.submit "#{notification.comment_content}" %></p>
-            
-          </li>
-        <% end %>
-      <% end %>
-    </ul>
-  </span>
+  <!-- モーダルの設定 -->
+  <div class="modal fade" id="commentNotificationModal" tabindex="-1" aria-labelledby="commentNotificationModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-slideout">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="commentNotificationModalLabel">コメント通知一覧</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+        </div>
+        <div class="modal-body">
+          <ul class="list-group">
+            <% @comment_notifications.each do |notification| %>
+              <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true, html: {class: "notification-form"} do |form| %>
+                <li class="list-group-item">
+                  <strong><%= notification.user.name %>さんからのコメント</strong>
+                  <p><%= link_to "#{notification.comment_content}", "#", class: "notification-link" %></p>
+                </li>
+              <% end %>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>
 <%= render "users/tweets/shared/tweets_table" %>
 <div id="new" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/users/tweets/index.html.erb
+++ b/app/views/users/tweets/index.html.erb
@@ -1,5 +1,24 @@
 <%= javascript_pack_tag "users/tweets" %>
 <% provide(:title, "つぶやき一覧") %>
+<% number_of_comment_notifications = @comment_notifications.count %>
+<% if number_of_comment_notifications > 0 %>
+  <span class="dropdown">
+  <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown">
+  <%= number_of_comment_notifications %>件のコメント通知があります。
+  </a>
+    <ul class="dropdown-menu">
+      <% @comment_notifications.each do |notification| %>
+        <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true do |form| %>
+          <li>
+            <strong><%= notification.user.name %>さんからのコメント</strong>
+            <p><%= form.submit "#{notification.comment_content}" %></p>
+            
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </span>
+<% end %>
 <%= render "users/tweets/shared/tweets_table" %>
 <div id="new" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
 <div id="edit" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -19,6 +19,8 @@
       <%= form_with(model: [@tweet, @comment], url: users_tweet_comments_path(@tweet, @comment), method: :post) do |form| %>
         <%= form.text_area :comment_content, class: "form-control mt-5" %>
         <%= form.hidden_field :tweet_id, value: @tweet.id %>
+        <%= form.hidden_field :recipient_id, value: @tweet.user_id %> <%# コメントを受け取るtweetユーザーのID %>
+        <%= form.hidden_field :confirmed, value: false %> <%# コメント確認フラグ。コメントを受け取るユーザーが未確認の場合はfalse,確認するとtrue。%>
         <%= form.submit 'コメントする', class: "btn btn-primary comment-submit" %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,11 @@ Rails.application.routes.draw do
       member do
         get 'index_user'
       end
-      resources :comments, only: [:create, :destroy, :update] #コメント機能
+      resources :comments, only: [:create, :destroy, :update] do #コメント機能
+        member do # 個々のコメントに対してアクセスできるカスタムアクションを定義する
+          patch 'confirmed_notification' #confirmed_notificationアクションに対するRESTfulなルーティングを定義
+        end
+      end
     end
     resources :inquiries #問い合わせ
   end

--- a/db/migrate/20230326040236_add_confirmed_to_comments.rb
+++ b/db/migrate/20230326040236_add_confirmed_to_comments.rb
@@ -1,0 +1,5 @@
+class AddConfirmedToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :comments, :confirmed, :boolean, default: false
+  end
+end

--- a/db/migrate/20230326064305_add_recipient_id_to_comments.rb
+++ b/db/migrate/20230326064305_add_recipient_id_to_comments.rb
@@ -1,0 +1,5 @@
+class AddRecipientIdToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :comments, :recipient_id, :integer, null: false
+  end
+end


### PR DESCRIPTION
### コメント通知機能

- つぶやきに対してコメント投稿すると、comment_content,tweet_id(コメントが投稿されるつぶやきのID),recipient_id(コメントを受け取るユーザーのID)がコメントテーブルに格納される。confirmed(コメントが未確認である場合はfalse,確認済の場合はtrue。デフォルト設定はfalse。)もコメントテーブルに格納される。
- つぶやきを投稿したユーザーのつぶやき一覧画面に、未確認のコメントの件数が表示される。
- 未確認のコメント件数を押下するとモーダル表示で未確認分のコメント通知のリンクが表示される。
- つぶやきユーザーがコメント通知リンクからコメントを確認すると同一のtweet_idのconfirmedの値がtrueに置き換わり、コメント確認済みとなる。

- 画面遷移イメージ
https://docs.google.com/spreadsheets/d/190uVaPsxUeCiMmEh_9YpsYYhcWXs7AkVUqwl1kZ6ueU/edit?usp=sharing