### PR TITLE
finish: bugfix/auto-line-break-bug

### DIFF
--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -2,9 +2,8 @@ import { marked } from 'marked'
 import "./articles"
 
 function resize_img(article){
-  article.find("img").each(function(){ //取得されたimg要素に対してeachメソッドで繰り返し処理
-    $(this).before('<br><br>'); //繰り返し処理中のimg要素の前に<br>要素を挿入
-    $(this).after('<br><br>'); //繰り返し処理中のimg要素の後に<br>要素を挿入
+  article.find("img").each(function(){ // 取得されたimg要素に対してeachメソッドで繰り返し処理
+    $(this).addClass('img-margin'); // img要素に対してimg-marginクラスを追加
   })
 }
 

--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -1,6 +1,13 @@
 import { marked } from 'marked'
 import "./articles"
 
+function resize_img(article){
+  article.find("img").each(function(){ //取得されたimg要素に対してeachメソッドで繰り返し処理
+    $(this).before('<br><br>'); //繰り返し処理中のimg要素の前に<br>要素を挿入
+    $(this).after('<br><br>'); //繰り返し処理中のimg要素の後に<br>要素を挿入
+  })
+}
+
 $(function(){
 
   if($(".article-content").length){

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -4,6 +4,12 @@
   border-radius: 5px;
 }
 
+// article_show.jsのresize_img関数にimg-marginクラスを追加
+.img-margin {
+  display: block; //ブロック要素として扱う。つまり新しい行で開始し次の要素は新しい行で始まる。
+  margin: 1em auto; //上下のマージンを1em,左右のマージンを自動（中央寄せ）で配置。
+}
+
 //以下index
 .articles-table {
   tr td {


### PR DESCRIPTION
### 記事投稿時に画像を貼り付けると画像の前後に自動で改行されるように実装。

<img width="1440" alt="スクリーンショット 2023-04-03 16 14 21" src="https://user-images.githubusercontent.com/99413634/229438714-08ff226d-ac99-46ad-b3d4-0ffa0ddbff1a.png">
