### PR TITLE
Feature/tweet link target

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'devise-i18n'
 gem 'rails-i18n', '~> 6.0'
 
 gem 'dotenv-rails'
+gem 'rinku'
 
 group :development, :test do
   # ERD生成

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -1,3 +1,5 @@
+require 'rinku'
+
 module Users
   class TweetsController < Users::Base
     # Userがログインしていないと、投稿を作成・編集・削除できない

--- a/app/javascript/packs/users/tweets.js
+++ b/app/javascript/packs/users/tweets.js
@@ -53,3 +53,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 });
+
+// つぶやき一覧でつぶやきを押下した際につぶやき詳細画面に遷移するメソッド
+$(document).on('turbolinks:load', function() { //Turbolinks がページをロードした後に実行されるイベントリスナー。要はリンクをクリックしてページがロードした後に実行される。
+  $('.tweet-post').on('click', function(e) { //tweet-postクラスが適用された要素がクリックされるときに実行されるイベントリスナー
+    if (!$(e.target).is('a')) { // クリックされた要素が<a>タグでない場合の条件式
+      window.location.href = $(this).data('tweet-url'); // 現在のページのURLを、クリックされたtweet-post要素のdata-tweet-url属性に設定されたURLに変更
+    }
+  });
+});

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -1,3 +1,11 @@
+.tweet-content {
+  word-break: break-all;
+  font-size: 20px; /* 文字の大きさを20pxに設定 */
+  background-color: white; /* 背景色を白に設定 */
+  border-radius: 10px; /* 角を丸くする */
+  padding: 20px;
+}
+
 .tweet-bgcolor {
   background-color: rgb(255, 255, 255);
 }

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -3,7 +3,15 @@
   font-size: 20px; /* 文字の大きさを20pxに設定 */
   background-color: white; /* 背景色を白に設定 */
   border-radius: 10px; /* 角を丸くする */
-  padding: 20px;
+  padding: 10px;
+}
+
+.table > tbody > tr > td.comment-content {
+  word-break: break-all;
+  font-size: 20px; /* 文字の大きさを20pxに設定 */
+  background-color: white; /* 背景色を白に設定 */
+  border-radius: 10px; /* 角を丸くする */
+  padding: 10px;
 }
 
 .tweet-bgcolor {
@@ -11,7 +19,7 @@
 }
 
 .comment-contents {
-  padding-bottom: 10px;
+  padding-bottom: 5px;
 }
 
 .break-all {

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -1,3 +1,12 @@
+.tweet-post {
+  word-break: break-all;
+  font-size: 20px; /* 文字の大きさを20pxに設定 */
+  background-color: white; /* 背景色を白に設定 */
+  border-radius: 10px; /* 角を丸くする */
+  padding: 10px;
+  cursor: pointer;
+}
+
 .tweet-content {
   word-break: break-all;
   font-size: 20px; /* 文字の大きさを20pxに設定 */

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -36,7 +36,7 @@
 }
 
 .table > tbody > tr > td.comment-bgcolor {
-  background-color:#ffffff;
+  background-color: #ffffff;
 }
 
 .comment-submit {
@@ -56,10 +56,10 @@
 .modal-dialog-slideout {
   max-width: 750px;
   position: fixed;
-  top: -25px;// 上側の位置を調整
+  top: -25px; // 上側の位置を調整
   // right: 0;
   bottom: 0;
-  left: 250px;//サイドバーの右側に表示
+  left: 250px; //サイドバーの右側に表示
   z-index: 1050;
   overflow: hidden;
   outline: 0;
@@ -79,7 +79,7 @@
   z-index: 1000;
 }
 
-// コメント通知一覧のモーダル内のクラス 
+// コメント通知一覧のモーダル内のクラス
 .notification-link {
   text-decoration: none;
   color: black;

--- a/app/lib/rinku.rb
+++ b/app/lib/rinku.rb
@@ -1,0 +1,1 @@
+require 'rinku'

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -29,10 +29,10 @@
             <table class= "table table-borderless">
               <tbody>
                 <tr>
-                  <td class="text-wrap col-6 fs-5 break-all" style="width: 40rem;">
-                    <%= link_to users_tweet_path(tweet.id), style: "color: black; text-decoration: none;" do %>
-                      <%= safe_join(tweet.post.split("\n"),tag(:br)) %>
-                    <% end %>
+                  <td>
+                    <div class="tweet-post" data-tweet-url="<%= users_tweet_path(tweet.id) %>">
+                      <%= raw Rinku.auto_link(simple_format(tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+                    </div>
                   </td>
                   <td class="dropdown">
                     <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -48,7 +48,7 @@
         </div><!-- /.modal-dialog -->
       </div><!-- /.modal -->
 
-      <div class="comment-contents mb-5 ">
+      <div class="comment-contents">
         <div class="row row-cols-auto">
           <div class="comment-header">
             <strong><%= comment.user.name %></strong>
@@ -60,8 +60,8 @@
         <table class="table table-borderless">
           <tbody>
             <tr>
-              <td class="text-wrap rounded-2 comment-bgcolor break-all" style="width: 30rem;">
-                <%= safe_join(comment.comment_content.split("\n"),tag(:br)) %>
+              <td class="comment-content">
+                <%= raw Rinku.auto_link(simple_format(comment.comment_content.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
               </td>
               <td class="dropdown col-1 rounded-2">
                 <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -10,10 +10,8 @@
         <%= l(@tweet.created_at, format: :long) %>
       </div>
     </div>
-    <div class="row">
-      <div class="text-wrap rounded-2 tweet-bgcolor mb-5 fs-4 break-all" style="width: auto;">
-        <%= safe_join(@tweet.post.split("\n"),tag(:br)) %>
-      </div>
+    <div class="tweet-content">
+      <%= raw Rinku.auto_link(simple_format(@tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
     </div>
     <div class="comment-create-form form-group">
       <%= form_with(model: [@tweet, @comment], url: users_tweet_comments_path(@tweet, @comment), method: :post) do |form| %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,6 @@ module App
         helper_specs:     false, # helper specは作らない
         routing_specs:    false      # routing specは作らない
     end
+    config.autoload_paths += %W(#{config.root}/lib)
   end
 end


### PR DESCRIPTION
### つぶやき機能 つぶやきとコメントにurlリンクを押下で新しいタブでリンク先を表示させる。(feature/tweet-link-target)

- つぶやき一覧画面で、つぶやきに表示されているURLリンクを押下すると新しいタブでリンクを開く。URL以外の箇所を押下するとつぶやき詳細に遷移する。
- つぶやき詳細画面で、つぶやきとコメントに表示されているURLリンクを押下すると新しいタブでリンクを開く。
- gem 'rinku'を追加してテキストをURLリンクにしています。

![スクリーンショット 2023-04-06 11 44 23（2）](https://user-images.githubusercontent.com/99413634/230262793-220c6fe4-647c-43d0-b5bb-cfa4048ad310.png)
![スクリーンショット 2023-04-06 11 46 41（2）](https://user-images.githubusercontent.com/99413634/230262802-d2eaa696-5a19-4e18-aa7a-307a602f1c0c.png)
