### PR TITLE
finish: feature/post-header-border

### DIFF
--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -1,43 +1,51 @@
-import { marked } from 'marked'
-import "./articles"
+import { marked } from "marked";
+import "./articles";
 
-function markdown_preview(content){
-  if($.type(content) == "string"){
-    content = mathtodollars(content);
-    content = marked(content)
-  }
-  var preview = $('.preview')
-  preview.html(content);
-  var pre = preview.find('pre')
-  pre.each(function(){
-    makecodeblock($(this))
-  })
-  resize_img(preview)
+function auto_line_break_img(article) {
+  article.find("img").each(function () {
+    // 取得されたimg要素に対してeachメソッドで繰り返し処理
+    $(this).addClass("img-margin"); // img要素に対してimg-marginクラスを追加
+  });
 }
 
-$(function(){
-  
+function markdown_preview(content) {
+  if ($.type(content) == "string") {
+    content = mathtodollars(content);
+    content = marked(content);
+  }
+  var preview = $(".preview");
+  preview.html(content);
+  var pre = preview.find("pre");
+  pre.each(function () {
+    makecodeblock($(this));
+  });
+  resize_img(preview);
+  auto_line_break_img(preview);
+}
+
+$(function () {
   var editor = $(".markdown-editor");
   var preview = $(".preview");
   preview.height(editor.height());
-  $('.editor-side .card').height($('.preview-side .card').height())
-  
-  if($(".markdown-editor").val()){
-    var content = $(".markdown-editor").text()
-    markdown_preview(content)
+  $(".editor-side .card").height($(".preview-side .card").height());
+
+  if ($(".markdown-editor").val()) {
+    var content = $(".markdown-editor").text();
+    markdown_preview(content);
   }
 
-  $('.markdown-editor').keyup(function(event){
-    var content = $(this).val()
-    markdown_preview(content)
+  $(".markdown-editor").keyup(function (event) {
+    var content = $(this).val();
+    markdown_preview(content);
   });
 
-  $('.markdown-editor').on('drop', function(e) { //dropのイベントをハンドル
+  $(".markdown-editor").on("drop", function (e) {
+    //dropのイベントをハンドル
     e.preventDefault(); //元の動きを止める処理
     var image = e.originalEvent.dataTransfer.files[0]; //ドロップされた画像の1件目を取得
     var formData = new FormData();
-    formData.append('image', image); // FormDataに画像を追加
-    formData.append('user_id', e.target.dataset.userId); // FormDataに画像を追加
+    formData.append("image", image); // FormDataに画像を追加
+    formData.append("user_id", e.target.dataset.userId); // FormDataに画像を追加
 
     // ajaxで画像をアップロード
     $.ajax({
@@ -46,30 +54,29 @@ $(function(){
       data: formData,
       dataType: "json",
       contentType: false,
-      processData: false
+      processData: false,
     })
-    .done(function(data, textStatus, jqXHR){
-      setImage(data['name'], data['url'])
-      resize_img($(".preview"))
-    })
-    .fail(function(jqXHR, textStatus, errorThrown){
-      alert("画像の挿入に失敗しました。");
-    });
+      .done(function (data, textStatus, jqXHR) {
+        setImage(data["name"], data["url"]);
+        resize_img($(".preview"));
+      })
+      .fail(function (jqXHR, textStatus, errorThrown) {
+        alert("画像の挿入に失敗しました。");
+      });
   });
 
   // テキストエリアに画像タグを追加する関数
   function setImage(name, url) {
-    var textarea = $('textarea').get(0);
+    var textarea = $("textarea").get(0);
     var sentence = textarea.value;
-    var len      = sentence.length;
-    var pos      = textarea.selectionStart;
-    var before   = sentence.substr(0, pos);
-    var word     = '<img alt="' + name + '" src="' + url + '">';
-    var after    = sentence.substr(pos, len);
+    var len = sentence.length;
+    var pos = textarea.selectionStart;
+    var before = sentence.substr(0, pos);
+    var word = '<img alt="' + name + '" src="' + url + '">';
+    var after = sentence.substr(pos, len);
     sentence = before + word + after;
     textarea.value = sentence;
-    var content = marked(textarea.value)
+    var content = marked(textarea.value);
     $(".preview").html(content);
   }
-
 });

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -1,51 +1,50 @@
-import { marked } from "marked";
-import "./articles";
+import { marked } from 'marked'
+import "./articles"
 
 function auto_line_break_img(article) {
-  article.find("img").each(function () {
-    // 取得されたimg要素に対してeachメソッドで繰り返し処理
+  article.find("img").each(function () { // 取得されたimg要素に対してeachメソッドで繰り返し処理
     $(this).addClass("img-margin"); // img要素に対してimg-marginクラスを追加
   });
 }
 
-function markdown_preview(content) {
-  if ($.type(content) == "string") {
+function markdown_preview(content){
+  if($.type(content) == "string"){
     content = mathtodollars(content);
-    content = marked(content);
+    content = marked(content)
   }
-  var preview = $(".preview");
+  var preview = $('.preview')
   preview.html(content);
-  var pre = preview.find("pre");
-  pre.each(function () {
-    makecodeblock($(this));
-  });
-  resize_img(preview);
-  auto_line_break_img(preview);
+  var pre = preview.find('pre')
+  pre.each(function(){
+    makecodeblock($(this))
+  })
+  resize_img(preview)
+  auto_line_break_img(preview)
 }
 
-$(function () {
+$(function(){
+  
   var editor = $(".markdown-editor");
   var preview = $(".preview");
   preview.height(editor.height());
-  $(".editor-side .card").height($(".preview-side .card").height());
-
-  if ($(".markdown-editor").val()) {
-    var content = $(".markdown-editor").text();
-    markdown_preview(content);
+  $('.editor-side .card').height($('.preview-side .card').height())
+  
+  if($(".markdown-editor").val()){
+    var content = $(".markdown-editor").text()
+    markdown_preview(content)
   }
 
-  $(".markdown-editor").keyup(function (event) {
-    var content = $(this).val();
-    markdown_preview(content);
+  $('.markdown-editor').keyup(function(event){
+    var content = $(this).val()
+    markdown_preview(content)
   });
 
-  $(".markdown-editor").on("drop", function (e) {
-    //dropのイベントをハンドル
+  $('.markdown-editor').on('drop', function(e) { //dropのイベントをハンドル
     e.preventDefault(); //元の動きを止める処理
     var image = e.originalEvent.dataTransfer.files[0]; //ドロップされた画像の1件目を取得
     var formData = new FormData();
-    formData.append("image", image); // FormDataに画像を追加
-    formData.append("user_id", e.target.dataset.userId); // FormDataに画像を追加
+    formData.append('image', image); // FormDataに画像を追加
+    formData.append('user_id', e.target.dataset.userId); // FormDataに画像を追加
 
     // ajaxで画像をアップロード
     $.ajax({
@@ -54,29 +53,30 @@ $(function () {
       data: formData,
       dataType: "json",
       contentType: false,
-      processData: false,
+      processData: false
     })
-      .done(function (data, textStatus, jqXHR) {
-        setImage(data["name"], data["url"]);
-        resize_img($(".preview"));
-      })
-      .fail(function (jqXHR, textStatus, errorThrown) {
-        alert("画像の挿入に失敗しました。");
-      });
+    .done(function(data, textStatus, jqXHR){
+      setImage(data['name'], data['url'])
+      resize_img($(".preview"))
+    })
+    .fail(function(jqXHR, textStatus, errorThrown){
+      alert("画像の挿入に失敗しました。");
+    });
   });
 
   // テキストエリアに画像タグを追加する関数
   function setImage(name, url) {
-    var textarea = $("textarea").get(0);
+    var textarea = $('textarea').get(0);
     var sentence = textarea.value;
-    var len = sentence.length;
-    var pos = textarea.selectionStart;
-    var before = sentence.substr(0, pos);
-    var word = '<img alt="' + name + '" src="' + url + '">';
-    var after = sentence.substr(pos, len);
+    var len      = sentence.length;
+    var pos      = textarea.selectionStart;
+    var before   = sentence.substr(0, pos);
+    var word     = '<img alt="' + name + '" src="' + url + '">';
+    var after    = sentence.substr(pos, len);
     sentence = before + word + after;
     textarea.value = sentence;
-    var content = marked(textarea.value);
+    var content = marked(textarea.value)
     $(".preview").html(content);
   }
+
 });

--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -1,68 +1,85 @@
-import { marked } from 'marked'
-import "./articles"
+import { marked } from "marked";
+import "./articles";
 
-function resize_img(article){
-  article.find("img").each(function(){ // 取得されたimg要素に対してeachメソッドで繰り返し処理
-    $(this).addClass('img-margin'); // img要素に対してimg-marginクラスを追加
-  })
+function auto_line_break_img(article) {
+  article.find("img").each(function () {
+    // 取得されたimg要素に対してeachメソッドで繰り返し処理
+    $(this).addClass("img-margin"); // img要素に対してimg-marginクラスを追加
+  });
 }
 
-$(function(){
-
-  if($(".article-content").length){
-    var article = $(".article-content")
-    var content = article.data("article")
-    if($.type(content) == "string"){
+$(function () {
+  if ($(".article-content").length) {
+    var article = $(".article-content");
+    var content = article.data("article");
+    if ($.type(content) == "string") {
       content = mathtodollars(content);
-      content = marked(content)
+      content = marked(content);
     }
     article.html(content);
-    var pre = article.find("pre")
-    pre.each(function(){
-      makecodeblock($(this))
-      var coderef = $(this).parent().prev()
-      copybtn(coderef)
-    })
-    resize_img(article)
+    var pre = article.find("pre");
+    pre.each(function () {
+      makecodeblock($(this));
+      var coderef = $(this).parent().prev();
+      copybtn(coderef);
+    });
+    resize_img(article);
+    auto_line_break_img(article);
   }
 
-  $(window).on('load', function () {
-    $(".article-content").find("img").each(function(){
-      $(this).wrap('<a href="" class="zoomin-img" data-bs-toggle="modal" data-bs-target="#zoominImgModal"></a>')
-    })
+  $(window).on("load", function () {
+    $(".article-content")
+      .find("img")
+      .each(function () {
+        $(this).wrap(
+          '<a href="" class="zoomin-img" data-bs-toggle="modal" data-bs-target="#zoominImgModal"></a>'
+        );
+      });
 
-    $('.zoomin-img').on('click', function(){
-      var img = $('.zoomin-modal').children()
-      if(img.length){
-        img.remove()
+    $(".zoomin-img").on("click", function () {
+      var img = $(".zoomin-modal").children();
+      if (img.length) {
+        img.remove();
       }
-      var src = $(this).children('img').attr('src') 
-      $('.zoomin-modal').append('<img src="' + src + '" width="100%" height="100%">')
-    })
+      var src = $(this).children("img").attr("src");
+      $(".zoomin-modal").append(
+        '<img src="' + src + '" width="100%" height="100%">'
+      );
+    });
   });
 
-  $(".btn-messe").click(function(){
-    var codecopy = $(this).parent(".code-copy")
+  $(".btn-messe").click(function () {
+    var codecopy = $(this).parent(".code-copy");
     var pre = codecopy.next(".highlight").find("pre");
-    var btn = codecopy.children(".btn-messe").children(".clipboard")
-    var messe = codecopy.children(".btn-messe").children(".messe")
-    btn.hide()
-    messe.show()
+    var btn = codecopy.children(".btn-messe").children(".clipboard");
+    var messe = codecopy.children(".btn-messe").children(".messe");
+    btn.hide();
+    messe.show();
     navigator.clipboard.writeText(pre.contents().text()).then(
-      success => messe.show(),
-      error => alert('コピーに失敗しました。')
+      (success) => messe.show(),
+      (error) => alert("コピーに失敗しました。")
     );
-    setTimeout(function(){
-      messe.hide()
-      btn.show()
-    },1500);    
-  })
-})
+    setTimeout(function () {
+      messe.hide();
+      btn.show();
+    }, 1500);
+  });
+});
 
-function copybtn(coderef){
-  coderef.after('<div class="code-copy"></div>')
-  var codecopy = coderef.next(".code-copy")
-  codecopy.css({"float": "right", "margin": "5px 20px 0 0", "cursor": "pointer", "color": "white"})
-  codecopy.append('<div class="btn-messe"><span class="far fa-copy clipboard"></span><span class="messe" style="display: none;">Copied!</span></div>')
-  codecopy.children('.btn-messe').children('.messe').css({"font-size": "smaller", "margin": "5px"})
+function copybtn(coderef) {
+  coderef.after('<div class="code-copy"></div>');
+  var codecopy = coderef.next(".code-copy");
+  codecopy.css({
+    float: "right",
+    margin: "5px 20px 0 0",
+    cursor: "pointer",
+    color: "white",
+  });
+  codecopy.append(
+    '<div class="btn-messe"><span class="far fa-copy clipboard"></span><span class="messe" style="display: none;">Copied!</span></div>'
+  );
+  codecopy
+    .children(".btn-messe")
+    .children(".messe")
+    .css({ "font-size": "smaller", margin: "5px" });
 }

--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -1,85 +1,69 @@
-import { marked } from "marked";
-import "./articles";
+import { marked } from 'marked'
+import "./articles"
 
 function auto_line_break_img(article) {
-  article.find("img").each(function () {
-    // 取得されたimg要素に対してeachメソッドで繰り返し処理
+  article.find("img").each(function () { // 取得されたimg要素に対してeachメソッドで繰り返し処理
     $(this).addClass("img-margin"); // img要素に対してimg-marginクラスを追加
   });
 }
 
-$(function () {
-  if ($(".article-content").length) {
-    var article = $(".article-content");
-    var content = article.data("article");
-    if ($.type(content) == "string") {
+$(function(){
+
+  if($(".article-content").length){
+    var article = $(".article-content")
+    var content = article.data("article")
+    if($.type(content) == "string"){
       content = mathtodollars(content);
-      content = marked(content);
+      content = marked(content)
     }
     article.html(content);
-    var pre = article.find("pre");
-    pre.each(function () {
-      makecodeblock($(this));
-      var coderef = $(this).parent().prev();
-      copybtn(coderef);
-    });
-    resize_img(article);
-    auto_line_break_img(article);
+    var pre = article.find("pre")
+    pre.each(function(){
+      makecodeblock($(this))
+      var coderef = $(this).parent().prev()
+      copybtn(coderef)
+    })
+    resize_img(article)
+    auto_line_break_img(article)
   }
 
-  $(window).on("load", function () {
-    $(".article-content")
-      .find("img")
-      .each(function () {
-        $(this).wrap(
-          '<a href="" class="zoomin-img" data-bs-toggle="modal" data-bs-target="#zoominImgModal"></a>'
-        );
-      });
+  $(window).on('load', function () {
+    $(".article-content").find("img").each(function(){
+      $(this).wrap('<a href="" class="zoomin-img" data-bs-toggle="modal" data-bs-target="#zoominImgModal"></a>')
+    })
 
-    $(".zoomin-img").on("click", function () {
-      var img = $(".zoomin-modal").children();
-      if (img.length) {
-        img.remove();
+    $('.zoomin-img').on('click', function(){
+      var img = $('.zoomin-modal').children()
+      if(img.length){
+        img.remove()
       }
-      var src = $(this).children("img").attr("src");
-      $(".zoomin-modal").append(
-        '<img src="' + src + '" width="100%" height="100%">'
-      );
-    });
+      var src = $(this).children('img').attr('src') 
+      $('.zoomin-modal').append('<img src="' + src + '" width="100%" height="100%">')
+    })
   });
 
-  $(".btn-messe").click(function () {
-    var codecopy = $(this).parent(".code-copy");
+  $(".btn-messe").click(function(){
+    var codecopy = $(this).parent(".code-copy")
     var pre = codecopy.next(".highlight").find("pre");
-    var btn = codecopy.children(".btn-messe").children(".clipboard");
-    var messe = codecopy.children(".btn-messe").children(".messe");
-    btn.hide();
-    messe.show();
+    var btn = codecopy.children(".btn-messe").children(".clipboard")
+    var messe = codecopy.children(".btn-messe").children(".messe")
+    btn.hide()
+    messe.show()
     navigator.clipboard.writeText(pre.contents().text()).then(
-      (success) => messe.show(),
-      (error) => alert("コピーに失敗しました。")
+      success => messe.show(),
+      error => alert('コピーに失敗しました。')
     );
-    setTimeout(function () {
-      messe.hide();
-      btn.show();
-    }, 1500);
-  });
-});
+    setTimeout(function(){
+      messe.hide()
+      btn.show()
+    },1500);    
+  })
+})
 
-function copybtn(coderef) {
-  coderef.after('<div class="code-copy"></div>');
-  var codecopy = coderef.next(".code-copy");
-  codecopy.css({
-    float: "right",
-    margin: "5px 20px 0 0",
-    cursor: "pointer",
-    color: "white",
-  });
-  codecopy.append(
-    '<div class="btn-messe"><span class="far fa-copy clipboard"></span><span class="messe" style="display: none;">Copied!</span></div>'
-  );
-  codecopy
-    .children(".btn-messe")
-    .children(".messe")
-    .css({ "font-size": "smaller", margin: "5px" });
+function copybtn(coderef){
+  coderef.after('<div class="code-copy"></div>')
+  var codecopy = coderef.next(".code-copy")
+  codecopy.css({"float": "right", "margin": "5px 20px 0 0", "cursor": "pointer", "color": "white"})
+  codecopy.append('<div class="btn-messe"><span class="far fa-copy clipboard"></span><span class="messe" style="display: none;">Copied!</span></div>')
+  codecopy.children('.btn-messe').children('.messe').css({"font-size": "smaller", "margin": "5px"})
 }

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -4,24 +4,30 @@
   border-radius: 5px;
 }
 
-// auto_line_break_img関数にimg-marginクラスを追加
+/* auto_line_break_img関数にimg-marginクラスを追加 */
 .img-margin {
   display: block; //ブロック要素として扱う。つまり新しい行で開始し次の要素は新しい行で始まる。
   margin: 1em auto; //上下のマージンを1em,左右のマージンを自動（中央寄せ）で配置。
 }
 
-// 記事詳細とプレビューのh1タグ、h2タグの下に動的に罫線を追加
-.article-content h1,
-.article-content h2,
-.card-body h1,
-.card-body h2 {
+/* 記事詳細とプレビューのh1〜h6タグ下に動的に罫線を追加 */
+.article-content h1, .article-content h2, .article-content h3, .article-content h4, .article-content h5, .article-content h6,
+.card-body h1, .card-body h2, .card-body h3, .card-body h4, .card-body h5, .card-body h6 {
   position: relative; // 親要素を基準に下の擬似要素の位置を決めるために記述。
 }
 
 .article-content h1::after,
 .article-content h2::after,
+.article-content h3::after,
+.article-content h4::after,
+.article-content h5::after,
+.article-content h6::after,
 .card-body h1::after,
-.card-body h2::after {
+.card-body h2::after,
+.card-body h3::after,
+.card-body h4::after,
+.card-body h5::after,
+.card-body h6::after {
   content: "";
   position: absolute; // 疑似要素を親要素を基準に位置を決めるために記述。
   left: 0;

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -4,10 +4,31 @@
   border-radius: 5px;
 }
 
-// article_show.jsのresize_img関数にimg-marginクラスを追加
+// auto_line_break_img関数にimg-marginクラスを追加
 .img-margin {
   display: block; //ブロック要素として扱う。つまり新しい行で開始し次の要素は新しい行で始まる。
   margin: 1em auto; //上下のマージンを1em,左右のマージンを自動（中央寄せ）で配置。
+}
+
+// 記事詳細とプレビューのh1タグ、h2タグの下に動的に罫線を追加
+.article-content h1,
+.article-content h2,
+.card-body h1,
+.card-body h2 {
+  position: relative; // 親要素を基準に下の擬似要素の位置を決めるために記述。
+}
+
+.article-content h1::after,
+.article-content h2::after,
+.card-body h1::after,
+.card-body h2::after {
+  content: "";
+  position: absolute; // 疑似要素を親要素を基準に位置を決めるために記述。
+  left: 0;
+  right: 0;
+  bottom: -5px;
+  height: 1px; // 罫線の高さ
+  background: #d0cece; //罫線の色
 }
 
 //以下index


### PR DESCRIPTION
## 記事詳細 見出しを投稿したらhrタグを動的に表示させる
qiitaやgithubを参考にしてh1,h2タグにアンダーラインが表示されるようにしてます。
- 記事詳細とプレビューのh1タグ、h2タグの下に動的に罫線を追加するためにcssにarticles.scssに記述。

また、記事投稿時画像を貼り付けた際に自動で改行させる関数名を機能に即したものに変更しています。

https://user-images.githubusercontent.com/99413634/230909808-e4d48620-eff2-478c-912b-10ee67fbcabd.mp4

