### PR TITLE
finish: fix/wide-editor-preview

### DIFF
--- a/app/javascript/stylesheets/users.scss
+++ b/app/javascript/stylesheets/users.scss
@@ -167,7 +167,10 @@
 }
 
 .div-title-form {
-  width: 650px;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .profile-title-form {

--- a/app/javascript/stylesheets/users/articles.scss
+++ b/app/javascript/stylesheets/users/articles.scss
@@ -46,3 +46,35 @@
     cursor: pointer;
   }
 }
+
+
+// 以下new
+.editor-side {
+  padding: 0;
+  margin-left: 0;
+}
+
+.preview-side { 
+  padding: 0;
+  margin-right: 0; 
+}
+
+.preview {
+  margin: 0;
+}
+
+
+.div-title-form, .div-subtitle-form {
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 0;
+  margin-right: 0; 
+}
+
+.markdown-editor {
+  padding: 6px 12px;
+}
+
+.card-body, .editor-body {
+  padding: 0;
+}

--- a/app/views/users/articles/new.html.erb
+++ b/app/views/users/articles/new.html.erb
@@ -1,7 +1,7 @@
 <%= javascript_pack_tag "users/articles_new_and_edit" %>
 <% provide(:title,  "記事投稿") %>
 <div class="content">
-  <div class="container">
+  <div class="container-fluid">
     <%= render "users/articles/shared/article_form_and_preview", btn_name: "投稿", url: users_articles_path(dashboard: @dashboard, page: params[:page]), method: :post %>
   </div>
 </div>

--- a/app/views/users/articles/shared/_article_form_and_preview.html.erb
+++ b/app/views/users/articles/shared/_article_form_and_preview.html.erb
@@ -1,19 +1,19 @@
 <%= form_with(model: @article, url: url, method: method, local: true) do |f| %>
   <div class="row mt-4">
-    <div class="col-10 offset-1 div-title-form">
+    <div class="col-12 div-title-form">
       <%= f.text_field :title, placeholder: Article.human_attribute_name(:title), class: "form-control title-form" %>
     </div>
-    <div class="col-10 offset-1 my-2">
+    <div class="col-12 my-2 div-subtitle-form">
       <%= f.text_field :sub_title, placeholder: Article.human_attribute_name(:sub_title), class: "form-control subtitle-form" %>
     </div>
     
-    <div class="col-5 offset-1 editor-side">
+    <div class="col-6 editor-side">
       <div class="card card-outline card-info">
         <div class="card-header">
           <h3 class="card-title text-center">エディター</h3>
         </div>
         <div class="card-body">
-          <div class="col-12">
+          <div class="col-12 editor-body">
             <%= f.text_area :content, placeholder: Article.human_attribute_name(:content), cols: 30, rows: 100,
               class: "form-control markdown-editor", data: {user_id: current_user.id} %>
           </div>
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <div class="col-5 preview-side">
+    <div class="col-6 preview-side">
       <div class="card card-outline card-info d-flex flex-column justify-content-start">
         <div class="card-header">
           <h3 class="card-title">プレビュー</h3>
@@ -29,7 +29,7 @@
         <div class="card-body col-12">
           <% content = @article.content ? @article.content : "" %>
           <div class="preview form-control" style="overflow: scroll;"></div>
-          <div class="text-center div-btns mt-3">
+          <div class="text-center div-btns my-3">
             <%= f.submit btn_name, class: "btn btn-primary" %>
             <% if btn_name == "更新" && @show %>
               <%= link_to 'キャンセル', users_article_path(@article, dashboard: @dashboard, page: params[:page]), class: "btn btn-outline-dark" %>
@@ -45,4 +45,3 @@
     </div>
   </div>
 <% end %>
-


### PR DESCRIPTION
## 記事投稿のエディタとプレビューの幅を広げる
- bootstrapのcontainer要素をcontainer-fluidとし、エディタとプレビューを画面幅まで広げる。
- HTMLテンプレートのdiv要素のクラス属性でグリッドサイズを変更したり、paddingやmarginを記述して幅をできるだけ広げる。
- 併せて投稿ボタンとキャンセルボタンの位置を中央に修正しました。
<img width="1440" alt="スクリーンショット 2023-04-24 21 20 25" src="https://user-images.githubusercontent.com/99413634/233994962-4bd4bcaa-8238-44db-a5d5-3c145fe523e0.png">


<img width="1440" alt="スクリーンショット 2023-04-24 21 20 33" src="https://user-images.githubusercontent.com/99413634/233994796-fda9fe85-e975-4386-9b44-91e6ef3cd83f.png">

