### PR TITLE
Fix/tweet layout mobile

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -33,7 +33,11 @@ module Users
       redirect_back(fallback_location: root_path)
     end
 
-    def edit; end
+    def edit
+      respond_to do |format|
+        format.js
+      end
+    end
 
     def update
       if @tweet.update(tweet_params)

--- a/app/javascript/packs/users/tweets.js
+++ b/app/javascript/packs/users/tweets.js
@@ -15,7 +15,7 @@ const updateTimeAgo = (timestamp) => {
     const day = ("0" + date.getDate()).slice(-2);
     const hour = ("0" + date.getHours()).slice(-2);
     const minutes = ("0" + date.getMinutes()).slice(-2);
-    return `・${year}年${month}月${day}日 ${hour}:${minutes}`;
+    return `${year}年${month}月${day}日 ${hour}:${minutes}`;
   } else if (hoursAgo >= 1) {
     return `・${hoursAgo}時間前`;
   } else if (minutesAgo >= 1) {

--- a/app/javascript/packs/users/tweets.js
+++ b/app/javascript/packs/users/tweets.js
@@ -15,7 +15,7 @@ const updateTimeAgo = (timestamp) => {
     const day = ("0" + date.getDate()).slice(-2);
     const hour = ("0" + date.getHours()).slice(-2);
     const minutes = ("0" + date.getMinutes()).slice(-2);
-    return `${year}年${month}月${day}日 ${hour}:${minutes}`;
+    return `・${year}年${month}月${day}日 ${hour}:${minutes}`;
   } else if (hoursAgo >= 1) {
     return `・${hoursAgo}時間前`;
   } else if (minutesAgo >= 1) {
@@ -38,7 +38,7 @@ const updateTimestamps = () => {
 
 // コメント一覧のページが読み込まれた時に実行される関数
 document.addEventListener('DOMContentLoaded', () => {
-  setInterval(updateTimestamps, 1000); // 1秒ごとに更新する
+  setInterval(updateTimestamps); // 「1000分の1秒」ごとに更新する
 });
 
 // notification-linkクラスを持つリンクがクリックされたときにフォームが送信される

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -1,8 +1,5 @@
 .tweet-post {
   word-break: break-all;
-  font-size: 20px; /* 文字の大きさを20pxに設定 */
-  background-color: white; /* 背景色を白に設定 */
-  border-radius: 10px; /* 角を丸くする */
   padding: 10px;
   cursor: pointer;
 }
@@ -24,17 +21,34 @@
   padding-top: 5px;
 }
 
+.collapse-body {
+  margin-bottom: 20px;
+}
+
+.tweets-index-item:hover {
+  background-color: #f0f0f0; // グレーに変わる
+}
+
 .timestamp {
   font-size: small;
   color: #a2a2a2;
 }
 
-.table > tbody > tr > td.comment-content {
+.comment-content {
   word-break: break-all;
-  font-size: 20px; /* 文字の大きさを20pxに設定 */
-  background-color: white; /* 背景色を白に設定 */
-  border-radius: 10px; /* 角を丸くする */
-  padding: 10px;
+}
+
+.comment-box::after, .comment-list::after {
+  content: "";
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  height: 1px;
+  background: #d0cece; //罫線の色
+}
+
+.notification-label {
+  padding-bottom: 10px;
 }
 
 .tweet-bgcolor {
@@ -42,7 +56,7 @@
 }
 
 .comment-contents {
-  padding-bottom: 5px;
+  padding-bottom: 0px;
 }
 
 .break-all {
@@ -70,7 +84,7 @@
   max-width: 750px;
   position: fixed;
   top: -25px; // 上側の位置を調整
-  // right: 0;
+  right: 0;
   bottom: 0;
   left: 250px; //サイドバーの右側に表示
   z-index: 1050;
@@ -93,13 +107,11 @@
 }
 
 // コメント通知一覧のモーダル内のクラス
-.notification-link {
-  text-decoration: none;
-  color: black;
+.notification-link:hover {
+  background-color: #d1c5c5;
 }
 
-.notification-link:hover {
-  text-decoration: none;
-  color: black;
-  background-color: #d1c5c5;
+
+.list-group-item:hover {
+  background-color: #f0f0f0; // グレーに変わる
 }

--- a/app/javascript/stylesheets/users/tweets.scss
+++ b/app/javascript/stylesheets/users/tweets.scss
@@ -20,6 +20,15 @@
   height: auto;
 }
 
+.tweets-index-item {
+  padding-top: 5px;
+}
+
+.timestamp {
+  font-size: small;
+  color: #a2a2a2;
+}
+
 .table > tbody > tr > td.comment-content {
   word-break: break-all;
   font-size: 20px; /* 文字の大きさを20pxに設定 */
@@ -48,12 +57,11 @@
   margin-top: 5px;
 }
 
-.form-group textarea {
-  height: 200px;
-  max-width: 800px;
+// bootstrap5のモーダル
+.modalTrriger {
+  padding: 20px;
 }
 
-// bootstrap5のモーダル
 .modal {
   z-index: 2000;
 }

--- a/app/views/users/tweets/edit.js.erb
+++ b/app/views/users/tweets/edit.js.erb
@@ -1,2 +1,2 @@
-$("#edit").html("<%= escape_javascript(render 'edit') %>");
+$("#edit").html("<%= escape_javascript(render 'users/tweets/edit') %>");
 $("#edit").modal("show");

--- a/app/views/users/tweets/index.html.erb
+++ b/app/views/users/tweets/index.html.erb
@@ -3,7 +3,7 @@
 <% number_of_comment_notifications = @comment_notifications.count %>
 <% if number_of_comment_notifications > 0 %>
   <!-- モーダルのトリガー -->
-  <a href="#" data-bs-toggle="modal" data-bs-target="#commentNotificationModal">
+  <a class= "modalTrriger" href="#" data-bs-toggle="modal" data-bs-target="#commentNotificationModal">
     <%= number_of_comment_notifications %>件のコメント通知があります。
   </a>
   <!-- モーダルの設定 -->

--- a/app/views/users/tweets/index.html.erb
+++ b/app/views/users/tweets/index.html.erb
@@ -2,30 +2,22 @@
 <% provide(:title, "つぶやき一覧") %>
 <% number_of_comment_notifications = @comment_notifications.count %>
 <% if number_of_comment_notifications > 0 %>
-  <!-- モーダルのトリガー -->
-  <a class= "modalTrriger" href="#" data-bs-toggle="modal" data-bs-target="#commentNotificationModal">
-    <%= number_of_comment_notifications %>件のコメント通知があります。
-  </a>
-  <!-- モーダルの設定 -->
-  <div class="modal fade" id="commentNotificationModal" tabindex="-1" aria-labelledby="commentNotificationModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-slideout">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="commentNotificationModalLabel">コメント通知一覧</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
-        </div>
-        <div class="modal-body">
-          <ul class="list-group">
-            <% @comment_notifications.each do |notification| %>
-              <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true, html: {class: "notification-form"} do |form| %>
-                <li class="list-group-item">
-                  <strong><%= notification.user.name %>さんからのコメント</strong>
-                  <p><%= link_to "#{notification.comment_content}", "#", class: "notification-link" %></p>
-                </li>
-              <% end %>
+  <div class="col-12 col-sm-8 offset-sm-2">
+    <div class="notification-label">
+      <a href="#notification1" data-toggle="collapse"><%= number_of_comment_notifications %>件のコメント通知があります。</a><br>
+    </div>
+    <div id="notification1" class="collapse">
+      <div class="collapse-body">
+        <ul class="list-group">
+          <% @comment_notifications.each do |notification| %>
+            <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true, html: {class: "notification-form"} do |form| %>
+              <li class="list-group-item">
+                <strong><%= notification.user.name %>さんからのコメント</strong>
+                <p><%= link_to "#{notification.comment_content}", "#", class: "notification-link" %></p>
+              </li>
             <% end %>
-          </ul>
-        </div>
+          <% end %>
+        </ul>
       </div>
     </div>
   </div>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -3,12 +3,12 @@
     <div class="row">
       <% if @tweets.exists? %>
         <% @tweets.each do |tweet| %>
-          <div class="tweets-index-item">
-            <div class="card col-12 col-lg-8 offset-lg-2">
-              <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+          <div class="col-12 col-sm-8 offset-sm-2">
+            <div class="card tweets-index-item">
+            <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
               <div class="d-flex align-items-center">
                 <%= image_tag image , class: "rounded-circle", size: "60x60" %>
-                <div class="d-flex align-items-start flex-column justify-content-start">
+                <div class="d-flex align-items-start flex-column justify-content-start"> <%# flex-colmunは縦並び %>
                   <div class="px-0">
                     <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
                       <strong><%= tweet.user.name %>&nbsp;</strong>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -7,25 +7,16 @@
             <div class="card col-12 col-lg-8 offset-lg-2">
               <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
               <div class="d-flex align-items-center">
-                <%= image_tag image , class: "rounded-circle", size: "30x30" %>
-                <span class="px-2">
-                  <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
-                    <strong><%= tweet.user.name %>&nbsp;</strong>
-                  <% end %>
-                </span>
-                <time class="timestamp" data-time="<%= tweet.created_at.to_i %>"></time>
-                <div class="d-flex align-items-center ms-auto">
-                  <div class="commentIcon px-2">
-                    <%= link_to users_tweet_path(tweet.id), style: "color: black; text-decoration: none;" do %>
-                      <i class="fa-regular fa-comment fa-lg"></i>
-                      <% if tweet.comments.count > 0 %>
-                        &nbsp;<%= tweet.comments.count %>
-                      <% end %>
+                <%= image_tag image , class: "rounded-circle", size: "60x60" %>
+                <div class="d-flex align-items-start flex-column justify-content-start">
+                  <div class="px-0">
+                    <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
+                      <strong><%= tweet.user.name %>&nbsp;</strong>
                     <% end %>
                   </div>
-                  <div class="goodIcon px-2">
-                    <i class="fa-regular fa-heart fa-lg"></i>
-                  </div>
+                  <time class="timestamp" data-time="<%= tweet.created_at.to_i %>"></time>
+                </div>
+                <div class="d-flex align-items-center ms-auto">
                   <div class="dropdown">
                     <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>
                     <ul class="dropdown-menu test-color">
@@ -45,6 +36,19 @@
                     <%= image_tag image, class: "tweet-image" %>
                   <% end %>
                 <% end %>
+              </div>
+              <div class="d-flex align-items-center">
+                <div class="commentIcon px-2">
+                  <%= link_to users_tweet_path(tweet.id), style: "color: black; text-decoration: none;" do %>
+                    <i class="fa-regular fa-comment fa-lg"></i>
+                    <% if tweet.comments.count > 0 %>
+                      &nbsp;<%= tweet.comments.count %>
+                    <% end %>
+                  <% end %>
+                </div>
+                <div class="goodIcon px-2">
+                  <i class="fa-regular fa-heart fa-lg"></i>
+                </div>
               </div>
             </div>
           </div>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -1,45 +1,32 @@
 <div class="content">
   <div class="container">
-    <% if @tweets.exists? %>
-      <% @tweets.each do |tweet| %>
-        <div class="tweets-index-item">
-          <div class="col-6 offset-3">
-            <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
-            <table>
-              <tbody>
-                <tr>
-                  <td><%= image_tag image , class: "rounded-circle", size: "30x30" %><b class="caret"></td>
-                  <td>
-                    <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
-                      <strong><%= tweet.user.name %>&nbsp;</strong>
-                    <% end %>
-                  </td>
-                  <td>
-                    <span class="timestamp" data-time="<%= tweet.created_at.to_i %>">
-                      <%= time_ago_in_words(tweet.created_at) %>前
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-6 offset-3">
-            <table class= "table table-borderless">
-              <tbody>
-                <tr>
-                  <td>
-                    <div class="tweet-post" data-tweet-url="<%= users_tweet_path(tweet.id) %>">
-                      <%= raw Rinku.auto_link(simple_format(tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
-                      <% tweet.images.each do |image| %>
-                        <% if image.persisted? %>
-                          <%= image_tag image, class: "tweet-image" %>
-                        <% end %>
+    <div class="row">
+      <% if @tweets.exists? %>
+        <% @tweets.each do |tweet| %>
+          <div class="tweets-index-item">
+            <div class="card col-12 col-lg-8 offset-lg-2">
+              <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+              <div class="d-flex align-items-center">
+                <%= image_tag image , class: "rounded-circle", size: "30x30" %>
+                <span class="px-2">
+                  <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
+                    <strong><%= tweet.user.name %>&nbsp;</strong>
+                  <% end %>
+                </span>
+                <time class="timestamp" data-time="<%= tweet.created_at.to_i %>"></time>
+                <div class="d-flex align-items-center ms-auto">
+                  <div class="commentIcon px-2">
+                    <%= link_to users_tweet_path(tweet.id), style: "color: black; text-decoration: none;" do %>
+                      <i class="fa-regular fa-comment fa-lg"></i>
+                      <% if tweet.comments.count > 0 %>
+                        &nbsp;<%= tweet.comments.count %>
                       <% end %>
-                    </div>
-                  </td>
-                  <td class="dropdown">
+                    <% end %>
+                  </div>
+                  <div class="goodIcon px-2">
+                    <i class="fa-regular fa-heart fa-lg"></i>
+                  </div>
+                  <div class="dropdown">
                     <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>
                     <ul class="dropdown-menu test-color">
                       <li><%= link_to '詳細', index_user_users_tweet_path(tweet.user_id), class:"dropdown-item" %></li>
@@ -48,32 +35,25 @@
                         <li><%= link_to '削除', users_tweet_path(tweet), method: :delete, data: { confirm: 'Are you sure?' }, class:"dropdown-item" %></li>
                       <% end %>
                     </ul>
-                  </td>  
-                </tr>
-                <tr class="row row-cols-4 pb-5">
-                  <td class="pl-5 pt-0">
-                    <%= link_to users_tweet_path(tweet.id), style: "color: black; text-decoration: none;" do %>
-                      <i class="fa-regular fa-comment fa-lg"></i>
-                      <% if tweet.comments.count > 0 %>
-                        &nbsp;<%= tweet.comments.count %>
-                      <% end %>
-                    <% end %>
-                  </td>
-                  <td></td>
-                  <td class="pl-5 pt-0">
-                    <i class="fa-regular fa-heart fa-lg"></i>
-                  </td>
-                  <td></td>
-                </tr>
-              </tbody>
-            </table>
+                  </div>
+                </div>
+              </div>
+              <div class="tweet-post" data-tweet-url="<%= users_tweet_path(tweet.id) %>">
+                <%= raw Rinku.auto_link(simple_format(tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+                <% tweet.images.each do |image| %>
+                  <% if image.persisted? %>
+                    <%= image_tag image, class: "tweet-image" %>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
           </div>
+        <% end %>
+      <% else %>
+        <div>
+          <%= render 'users/shared/table_without_record' %>
         </div>
       <% end %>
-    <% else %>
-      <table>
-        <%= render 'users/shared/table_without_record' %>
-      </table>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -2,26 +2,31 @@
 <% provide(:title, "つぶやき詳細") %>
 <div class="container">
   <div class="row">
-    <div class="co-12 col-lg-10 offset-lg-1">
-      <div class="d-flex align-items-center">
-        <strong>
-          <%= @tweet.user.name %>
-        </strong>
-        <div>・
-          <%= l(@tweet.created_at, format: :long) %>
+    <div class="co-12 col-lg-8 offset-lg-2">
+      <div class="card">
+       <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+        <div class="d-flex align-items-center">
+          <%= image_tag image , class: "rounded-circle", size: "60x60" %>
+          <div class="d-flex align-items-start justify-content-start">
+            <strong>
+              <%= @tweet.user.name %>
+            </strong>
+            <div>・<%= l(@tweet.created_at, format: :long) %>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="tweet-content">
-        <%= raw Rinku.auto_link(simple_format(@tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
-          <% @tweet.images.each do |image| %>
-            <% if image.persisted? %>
-              <%= image_tag image, class: "tweet-image" %>
+        <div class="tweet-content">
+          <%= raw Rinku.auto_link(simple_format(@tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+            <% @tweet.images.each do |image| %>
+              <% if image.persisted? %>
+                <%= image_tag image, class: "tweet-image" %>
+              <% end %>
             <% end %>
-          <% end %>
+        </div>
       </div>
       <div class="comment-create-form form-group">
         <%= form_with(model: [@tweet, @comment], url: users_tweet_comments_path(@tweet, @comment), method: :post) do |form| %>
-          <%= form.text_area :comment_content, class: "form-control mt-5" %>
+          <%= form.text_area :comment_content, placeholder: "コメントしましょう！", class: "form-control mt-2" %>
           <%= form.hidden_field :tweet_id, value: @tweet.id %>
           <%= form.hidden_field :recipient_id, value: @tweet.user_id %> <%# コメントを受け取るtweetユーザーのID %>
           <%= form.hidden_field :confirmed, value: false %> <%# コメント確認フラグ。コメントを受け取るユーザーが未確認の場合はfalse,確認するとtrue。%>
@@ -29,47 +34,38 @@
         <% end %>
       </div>
       <% if @comments.exists? %>
-        <p class="fw-bold">〜コメント一覧〜</p>
+        <p class="comment-list fw-bold">〜コメント一覧〜</p>
       <% end %>
       <% @comments.each do |comment| %>
-      <!-- モーダルの設定 -->
-      <div class="modal fade" id="commentUpdateModal-<%= comment.id %>" tabindex="-1" aria-labelledby="commentUpdateModalLabel">
-        <div class="modal-dialog modal-lg form-group">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h1 class="modal-title fs-5" id="commentUpdateModal<%= comment.id %>">コメントの編集</h1>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
-            </div>
-            <%= form_with(model: comment, url: users_tweet_comment_path(@tweet, comment), local: true, method: :patch) do |f| %>
-              <div class="modal-body">
-                <%= f.text_area :comment_content, class: "form-control" %>
-                <%= f.hidden_field :tweet_id, value: @tweet.id %>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
-                <button type="submit" class="btn btn-primary">変更を保存</button>
-              </div><!-- /.modal-footer -->
-            <% end %>
-          </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-      </div><!-- /.modal -->
-
-      <div class="comment-contents">
-        <div class="row row-cols-auto">
-          <div class="comment-header">
-            <strong><%= comment.user.name %></strong>
-            <span class="timestamp" data-time="<%= comment.created_at.to_i %>">
-              <%= time_ago_in_words(comment.created_at) %>前
-            </span>
-          </div>
-        </div>
-        <table class="table table-borderless">
-          <tbody>
-            <tr>
-              <td class="comment-content">
-                <%= raw Rinku.auto_link(simple_format(comment.comment_content.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
-              </td>
-              <td class="dropdown col-1 rounded-2">
+        <div class="comment-box">
+          <!-- モーダルの設定 -->
+          <div class="modal fade" id="commentUpdateModal-<%= comment.id %>" tabindex="-1" aria-labelledby="commentUpdateModalLabel">
+            <div class="modal-dialog modal-lg form-group">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h1 class="modal-title fs-5" id="commentUpdateModal<%= comment.id %>">コメントの編集</h1>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+                </div>
+                <%= form_with(model: comment, url: users_tweet_comment_path(@tweet, comment), local: true, method: :patch) do |f| %>
+                  <div class="modal-body">
+                    <%= f.text_area :comment_content, class: "form-control" %>
+                    <%= f.hidden_field :tweet_id, value: @tweet.id %>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+                    <button type="submit" class="btn btn-primary">変更を保存</button>
+                  </div><!-- /.modal-footer -->
+                <% end %>
+              </div><!-- /.modal-content -->
+            </div><!-- /.modal-dialog -->
+          </div><!-- /.modal -->
+          <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+          <div class="comment-contents">
+            <div class="comment-header d-flex align-items-center">
+              <%= image_tag image , class: "rounded-circle", size: "30x30" %>
+              <strong><%= comment.user.name %></strong>
+              <span class="timestamp" data-time="<%= comment.created_at.to_i %>"></span>
+              <div class="dropdown d-flex align-items-center ms-auto">
                 <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>
                 <ul class="dropdown-menu test-color">
                   <% if comment.user == current_user %>
@@ -82,11 +78,13 @@
                     </li>
                   <% end %>
                 </ul>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+              </div>
+            </div>
+            <div class="comment-content">
+              <%= raw Rinku.auto_link(simple_format(comment.comment_content.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+            </div>
+          </div>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -1,36 +1,37 @@
 <%= javascript_pack_tag "users/tweets" %> <%# cssを反映させる%>
-<h1>つぶやき詳細</h1>
+<% provide(:title, "つぶやき詳細") %>
 <div class="container">
-  <div class="col-8 offset-2">
-    <div class="row row-cols-auto">
-      <div class="col fs-1">
-        <%= @tweet.user.name %>
+  <div class="row">
+    <div class="co-12 col-lg-10 offset-lg-1">
+      <div class="d-flex align-items-center">
+        <strong>
+          <%= @tweet.user.name %>
+        </strong>
+        <div>・
+          <%= l(@tweet.created_at, format: :long) %>
+        </div>
       </div>
-      <div class="col mt-4">
-        <%= l(@tweet.created_at, format: :long) %>
-      </div>
-    </div>
-    <div class="tweet-content">
-      <%= raw Rinku.auto_link(simple_format(@tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
-        <% @tweet.images.each do |image| %>
-          <% if image.persisted? %>
-            <%= image_tag image, class: "tweet-image" %>
+      <div class="tweet-content">
+        <%= raw Rinku.auto_link(simple_format(@tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+          <% @tweet.images.each do |image| %>
+            <% if image.persisted? %>
+              <%= image_tag image, class: "tweet-image" %>
+            <% end %>
           <% end %>
+      </div>
+      <div class="comment-create-form form-group">
+        <%= form_with(model: [@tweet, @comment], url: users_tweet_comments_path(@tweet, @comment), method: :post) do |form| %>
+          <%= form.text_area :comment_content, class: "form-control mt-5" %>
+          <%= form.hidden_field :tweet_id, value: @tweet.id %>
+          <%= form.hidden_field :recipient_id, value: @tweet.user_id %> <%# コメントを受け取るtweetユーザーのID %>
+          <%= form.hidden_field :confirmed, value: false %> <%# コメント確認フラグ。コメントを受け取るユーザーが未確認の場合はfalse,確認するとtrue。%>
+          <%= form.submit 'コメントする', class: "btn btn-primary comment-submit" %>
         <% end %>
-    </div>
-    <div class="comment-create-form form-group">
-      <%= form_with(model: [@tweet, @comment], url: users_tweet_comments_path(@tweet, @comment), method: :post) do |form| %>
-        <%= form.text_area :comment_content, class: "form-control mt-5" %>
-        <%= form.hidden_field :tweet_id, value: @tweet.id %>
-        <%= form.hidden_field :recipient_id, value: @tweet.user_id %> <%# コメントを受け取るtweetユーザーのID %>
-        <%= form.hidden_field :confirmed, value: false %> <%# コメント確認フラグ。コメントを受け取るユーザーが未確認の場合はfalse,確認するとtrue。%>
-        <%= form.submit 'コメントする', class: "btn btn-primary comment-submit" %>
+      </div>
+      <% if @comments.exists? %>
+        <p class="fw-bold">〜コメント一覧〜</p>
       <% end %>
-    </div>
-    <% if @comments.exists? %>
-      <p class="fw-bold">〜コメント一覧〜</p>
-    <% end %>
-    <% @comments.each do |comment| %>
+      <% @comments.each do |comment| %>
       <!-- モーダルの設定 -->
       <div class="modal fade" id="commentUpdateModal-<%= comment.id %>" tabindex="-1" aria-labelledby="commentUpdateModalLabel">
         <div class="modal-dialog modal-lg form-group">
@@ -86,6 +87,7 @@
           </tbody>
         </table>
       </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### つぶやき一覧とつぶやき詳細画面をスマホで見やすくレイアウトを変更
- bootstrapのグリッドシステムとd-flexユーティリティを使ってスマホ画面サイズでもレイアウトが崩れないようにレスポンシブデザインを実装。
具体的にはつぶやきユーザー名と投稿日時、コメントユーザー名と投稿日時、3点リーダーの配置やサイズを調整して、PCでもスマホでも見やすい表示ができるように調整しました。
- 以前はコメント通知のリンクを押下するとモーダルでコメント通知一覧が表示されていましたが、スマホレイアウトでは見づらいという問題がありました。そのため、表示方法を変更し、collapse要素を展開してコメント通知一覧を表示するようにしています。これにより、スマホ画面でもコメント通知一覧が見やすくなりました。

以下、実装イメージです。　
https://docs.google.com/spreadsheets/d/1OgmSNSRzHaECaY5H2wDiuHywEn9eblnZWGqmm-h6UDo/edit?usp=sharing
