### PR TITLE
set_sanitize_method

### DIFF
--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -9,38 +9,52 @@ function auto_line_break_img(article) {
 
 // 特定の要素をsanitizeするメソッド
 function sanitizeContent(content) {
-  content = content.replace(/<style[\s\S]*?<\/style>/gi, ''); //style要素を空欄に置き換える。
   content = content.replace(/<script[\s\S]*?<\/script>/gi, ''); //script要素を空欄に置き換える。
   content = content.replace(/<iframe[\s\S]*?<\/iframe>/gi, ''); //iframe要素を空欄に置き換える。
   return content;
 }
 
-function markdown_preview(content){
-  if($.type(content) == "string"){
-    content = sanitizeContent(content); //contentからstyleタグ,scriptタグ,iframeタグを除去。
+function markdown_preview(content) {
+  if ($.type(content) == "string") {
+    content = sanitizeContent(content); //contentからscriptタグ,iframeタグを除去。
     content = mathtodollars(content);
-    content = marked(content);
+    content = marked(content); // マークダウン形式のテキストHTMLに変換。
   }
-  var preview = $('.preview')
-  preview.html(content);
-  var pre = preview.find('pre')
-  pre.each(function(){
-    makecodeblock($(this))
-  })
-  resize_img(preview)
-  auto_line_break_img(preview)
-}
+
+  var virtualPreview = $("<div>"); // 新しい仮想DOM要素を作成
+  virtualPreview.html(content);
+
+  // プレビューコンテンツから<style>タグを抽出し、プレビュー用の<div>要素に適用する
+  const styles = virtualPreview.find("style");
+  styles.each(function () {
+    const styleContent = $(this).html(); // thisはstyles.each()関数の中で現在の反復（イテレーション）の対象となっている<style>タグ要素を指しています
+    const scopedStyleContent = styleContent.replace(/(^|\})\s*([^{]+)/g, '$1.preview $2');
+    $(this).html(scopedStyleContent);
+  });
+
+  var pre = virtualPreview.find("pre");
+  pre.each(function () {
+    makecodeblock($(this));
+  });
+  resize_img(virtualPreview);
+  auto_line_break_img(virtualPreview);
+
+  // 最後にプレビュー用のdiv要素の中身を置き換えます。
+  $(".preview").html(virtualPreview.html());
+};
+
+
 
 $(function(){
   
   var editor = $(".markdown-editor");
   var preview = $(".preview");
   preview.height(editor.height());
-  $('.editor-side .card').height($('.preview-side .card').height())
+  $('.editor-side .card').height($('.preview-side .card').height());
   
   if($(".markdown-editor").val()){
     var content = $(".markdown-editor").text()
-    markdown_preview(content)
+    markdown_preview(content);
   }
 
   $('.markdown-editor').keyup(function(event){

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -7,10 +7,19 @@ function auto_line_break_img(article) {
   });
 }
 
+// 特定の要素をsanitizeするメソッド
+function sanitizeContent(content) {
+  content = content.replace(/<style[\s\S]*?<\/style>/gi, ''); //style要素を空欄に置き換える。
+  content = content.replace(/<script[\s\S]*?<\/script>/gi, ''); //script要素を空欄に置き換える。
+  content = content.replace(/<iframe[\s\S]*?<\/iframe>/gi, ''); //iframe要素を空欄に置き換える。
+  return content;
+}
+
 function markdown_preview(content){
   if($.type(content) == "string"){
+    content = sanitizeContent(content); //contentからstyleタグ,scriptタグ,iframeタグを除去。
     content = mathtodollars(content);
-    content = marked(content)
+    content = marked(content);
   }
   var preview = $('.preview')
   preview.html(content);

--- a/app/javascript/packs/users/articles_show.js
+++ b/app/javascript/packs/users/articles_show.js
@@ -7,15 +7,30 @@ function auto_line_break_img(article) {
   });
 }
 
-$(function(){
+function applyScopedStyles(article) {
+  const styles = article.find("style"); // styleタグとその内容を取得。
+  styles.each(function() {
+    const styleContent = $(this).html(); // 現在処理中の<style>タグの内容を取得。例えば、li { font-size: 40px; }
+    const scopedStyleContent = styleContent.replace(/(^|\})\s*([^{]+)/g, '$1.article-content $2'); // 例えば「li」を「.article-content li」に置き換える。
+    $(this).html(scopedStyleContent);
+  });
+}
 
+$(function(){
   if($(".article-content").length){
     var article = $(".article-content")
     var content = article.data("article")
     if($.type(content) == "string"){
       content = mathtodollars(content);
-      content = marked(content)
+      // 新しい仮想DOM要素を作成し、マークダウンをHTMLに変換する前のコンテンツを適用します。
+      var virtualArticle = $("<div>");
+      virtualArticle.html(content);
+      // applyScopedStyles関数を適用します。
+      applyScopedStyles(virtualArticle);
+      // 次にmarkedでマークダウンをHTMLに変換します。
+      content = marked(virtualArticle.html());
     }
+    // 実際の.article-content要素の中身を置き換えます。
     article.html(content);
     var pre = article.find("pre")
     pre.each(function(){

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -21,13 +21,12 @@
       </div>
       <hr>
       <%# styleタグ、scriptタグ、iframeタグがgsubメソッドにより除去される。 %>
-      <% content = @article.content.gsub(/<style>.*<\/style>/m, '').gsub(/<script>.*<\/script>/m, '').gsub(/<iframe[\s\S]*?<\/iframe>/m, '') %>
+      <% content = @article.content.gsub(/<script>.*<\/script>/m, '').gsub(/<iframe[\s\S]*?<\/iframe>/m, '') %>
       <%# gsubメソッドで除去しきれてない他のHTML要素や属性が悪意のあるコードを含んでいる可能性があるため、sanitizeメソッドを使用することで悪意のあるタグやhtml要素を無効化する %>
-      <div class="m-4 article-content" data-article="<%= sanitize content %>"></div> 
+      <div class="m-4 article-content" data-article="<%= content %>"></div> 
     </div>
   </div>
 </div>
-
 <div class="modal fade" id="zoominImgModal" tabindex="-1" aria-labelledby="zoominImgModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -20,10 +20,9 @@
         </div>
       </div>
       <hr>
-      <%# styleタグ、scriptタグ、iframeタグがgsubメソッドにより除去される。 %>
+      <%# scriptタグ、iframeタグがgsubメソッドにより除去される。 %>
       <% content = @article.content.gsub(/<script>.*<\/script>/m, '').gsub(/<iframe[\s\S]*?<\/iframe>/m, '') %>
-      <%# gsubメソッドで除去しきれてない他のHTML要素や属性が悪意のあるコードを含んでいる可能性があるため、sanitizeメソッドを使用することで悪意のあるタグやhtml要素を無効化する %>
-      <div class="m-4 article-content" data-article="<%= content %>"></div> 
+      <div class="m-4 article-content" data-article="<%= content %>"></div>
     </div>
   </div>
 </div>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -20,7 +20,10 @@
         </div>
       </div>
       <hr>
-      <div class="m-4 article-content" data-article="<%= @article.content %>"></div>
+      <%# styleタグ、scriptタグ、iframeタグがgsubメソッドにより除去される。 %>
+      <% content = @article.content.gsub(/<style>.*<\/style>/m, '').gsub(/<script>.*<\/script>/m, '').gsub(/<iframe[\s\S]*?<\/iframe>/m, '') %>
+      <%# gsubメソッドで除去しきれてない他のHTML要素や属性が悪意のあるコードを含んでいる可能性があるため、sanitizeメソッドを使用することで悪意のあるタグやhtml要素を無効化する %>
+      <div class="m-4 article-content" data-article="<%= sanitize content %>"></div> 
     </div>
   </div>
 </div>


### PR DESCRIPTION
### マークダウンエディターに記述したCSSがアプリ全体に反映されるバグを解消

1. sanitizeメソッドを使用
マークダウンエディタにstyleタグで囲んだcssを記述すると、アプリ全体に反映される仕様になっていたので、sanitizeメソッドを使い、そもそもstyleタグをマークダウンエディタに記述しても反映されないような仕様に変更しました。
参考までにqiitaの記事作成のマークダウンエディタもstyleタグを記述しても反映されないです。
zennではstyleタグを記述した場合、文字列として反映される。cssを記述してstyleタグで囲んでもcssが効かないです。
sanitizeメソッドを使うことでxss攻撃の対策にもなります。

2. gsubメソッドを使用
sanitizeメソッドだけでは要素の内容が表示されるため、gsubメソッドを使用してstyle要素の内容を非表示にします。script要素、iframe要素の内容も非表示にするような仕様にしました。

画面イメージ
https://docs.google.com/spreadsheets/d/1Cvmj_U1rb3ArkQBLjeDbJ-0JLTyrAidGhzGHDQ5vzIU/edit?usp=sharing





