### PR TITLE
fix/tweet-comment-notification-modal-01

### DIFF
--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -38,8 +38,9 @@ module Users
     # 未確認の通知を確認するアクション
     def confirmed_notification
       @tweet = Tweet.find(params[:tweet_id])
-      @tweet.comments.where(confirmed: false, recipient_id: current_user.id).update_all(confirmed: true)
-      redirect_to users_tweet_path(@tweet)
+      @comment = @tweet.comments.find(params[:id])
+      @comment.update(confirmed: true)
+      redirect_to users_tweet_path(@tweet, anchor: "comment-#{@comment.id}")
     end
 
     private

--- a/app/views/users/tweets/index.html.erb
+++ b/app/views/users/tweets/index.html.erb
@@ -2,22 +2,37 @@
 <% provide(:title, "つぶやき一覧") %>
 <% number_of_comment_notifications = @comment_notifications.count %>
 <% if number_of_comment_notifications > 0 %>
-  <div class="col-12 col-sm-8 offset-sm-2">
-    <div class="notification-label">
-      <a href="#notification1" data-toggle="collapse"><%= number_of_comment_notifications %>件のコメント通知があります。</a><br>
-    </div>
-    <div id="notification1" class="collapse">
-      <div class="collapse-body">
-        <ul class="list-group">
-          <% @comment_notifications.each do |notification| %>
-            <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true, html: {class: "notification-form"} do |form| %>
-              <li class="list-group-item">
-                <strong><%= notification.user.name %>さんからのコメント</strong>
-                <p><%= link_to "#{notification.comment_content}", "#", class: "notification-link" %></p>
-              </li>
+  <!-- モーダルのトリガー -->
+  <a class= "modalTrriger" href="#" data-bs-toggle="modal" data-bs-target="#commentNotificationModal">
+    <%= number_of_comment_notifications %>件の未確認のコメントがあります。
+  </a>
+  <!-- モーダルの設定 -->
+  <div class="modal fade" id="commentNotificationModal" tabindex="-1" aria-labelledby="commentNotificationModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="commentNotificationModalLabel">コメント通知一覧</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+        </div>
+        <div class="modal-body">
+          <ul class="list-group">
+            <% @comment_notifications.each do |notification| %>
+              <%= form_with url: confirmed_notification_users_tweet_comment_path(notification.tweet, notification), method: :patch, local: true, html: {class: "notification-form", id: "comment-#{notification.id}"} do |form| %>
+                <li class="list-group-item">
+                  <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+                  <div class="d-flex align-items-center">
+                    <%= image_tag image , class: "rounded-circle", size: "60x60" %>
+                    <div class="d-flex flex-column align-items-start">
+                      <strong><%= notification.user.name %>さんがあなたのつぶやきにコメントしました。</strong>
+                      <p><%= link_to "#{truncate(notification.comment_content, omission: '...')}", "#", class: "notification-link" %></p>
+                      <time class="timestamp" data-time="<%= notification.created_at.to_i %>"></time>
+                    </div>
+                  </div>
+                </li>
+              <% end %>
             <% end %>
-          <% end %>
-        </ul>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -30,7 +30,7 @@
                 </div>
               </div>
               <div class="tweet-post" data-tweet-url="<%= users_tweet_path(tweet.id) %>">
-                <%= raw Rinku.auto_link(simple_format(tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+                <%= raw Rinku.auto_link(sanitize(simple_format(tweet.post.gsub(/ /, '&nbsp;'))), :all, 'target="_blank"') %>
                 <% tweet.images.each do |image| %>
                   <% if image.persisted? %>
                     <%= image_tag image, class: "tweet-image" %>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -16,7 +16,7 @@
           </div>
         </div>
         <div class="tweet-content">
-          <%= raw Rinku.auto_link(simple_format(@tweet.post.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+          <%= raw Rinku.auto_link(sanitize(simple_format(@tweet.post.gsub(/ /, '&nbsp;'))), :all, 'target="_blank"') %>
             <% @tweet.images.each do |image| %>
               <% if image.persisted? %>
                 <%= image_tag image, class: "tweet-image" %>
@@ -37,7 +37,7 @@
         <p class="comment-list fw-bold">〜コメント一覧〜</p>
       <% end %>
       <% @comments.each do |comment| %>
-        <div class="comment-box">
+        <div class="comment-box" id="comment-<%= comment.id %>">
           <!-- モーダルの設定 -->
           <div class="modal fade" id="commentUpdateModal-<%= comment.id %>" tabindex="-1" aria-labelledby="commentUpdateModalLabel">
             <div class="modal-dialog modal-lg form-group">
@@ -81,7 +81,7 @@
               </div>
             </div>
             <div class="comment-content">
-              <%= raw Rinku.auto_link(simple_format(comment.comment_content.gsub(/ /, '&nbsp;')), :all, 'target="_blank"') %>
+              <%= raw Rinku.auto_link(sanitize(simple_format(comment.comment_content.gsub(/ /, '&nbsp;'))), :all, 'target="_blank"') %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### つぶやき機能のコメント通知をcollapse表示からmodal表示に変更

概要に記載の通り。以下変更箇所に画像を貼り付けています。
https://docs.google.com/spreadsheets/d/1nYOH5YxbzIH4qv4W1HjGMh2oyGbm_G_EZdg3CNfhA3M/edit?usp=sharing

概要に記載していること以外にも以下の機能を追加してます。
- いつ通知が届いたのか表示する機能

仕様書を修正しました。仕様書と照らし合わせて確認お願いします。
https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=713047499

### 今後の課題
つぶやき一覧、つぶやき詳細、コメント通知一覧に表示している画像が正しく表示されていないため、正しく表示されるように修正します。
