### PR TITLE
動画詳細ページでの不具合修正

### DIFF
--- a/app/views/users/posts/show.html.erb
+++ b/app/views/users/posts/show.html.erb
@@ -18,9 +18,13 @@
     <td width="230"><%= simple_format(@post.body) %></td>
     <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=@post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
     <td>
-      <%= button_to '動画一覧', users_posts_path, method: :get ,class: "btn btn-primary" %><br>
-      <%= button_to '編集画面', edit_users_post_path(@post), method: :get ,class: "btn btn-success" %><br>
-      <%= button_to '削除', users_post_path(@post), method: :delete ,class: "btn btn-danger", data: {confirm: "#{@post.title}を削除してもよろしいですか？"} %>
+      <% if @post.user_id == current_user.id %>
+        <%= button_to '動画一覧', users_posts_path, method: :get ,class: "btn btn-primary" %><br>
+        <%= button_to '編集画面', edit_users_post_path(@post), method: :get ,class: "btn btn-success" %><br>
+        <%= button_to '削除', users_post_path(@post), method: :delete ,class: "btn btn-danger", data: {confirm: "#{@post.title}を削除してもよろしいですか？"} %>
+      <% else %>
+        <%= button_to '動画一覧', users_posts_path, method: :get ,class: "btn btn-primary" %><br>
+      <% end %>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## PRの概要
・一般ユーザー動画投稿一覧機能の動画詳細ページでの不具合修正。

## 不具合内容
・自分以外のユーザーの投稿でも「編集」、「削除」ボタンがあり押すとエラーになる。

## 実装内容
・if文で自分以外のユーザーの投稿の場合、「編集」、「削除」ボタンを出さないようにしました。
<img width="451" alt="image" src="https://github.com/nishinotakay/teac-output-new/assets/97861380/395850b1-971d-4a8c-ba32-3a6361339ed8">
![image](https://github.com/nishinotakay/teac-output-new/assets/97861380/46aa17a6-8186-42a8-9c8b-86caf3be0833)
