### PR TITLE
fixbug_tweets_and_comments-profile-image

### DIFF
--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -5,11 +5,11 @@
         <% @tweets.each do |tweet| %>
           <div class="col-12 col-sm-8 offset-sm-2">
             <div class="card tweets-index-item">
-            <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+            <% image = tweet.user.profile.present? && tweet.user.profile.image.present? ? tweet.user.profile&.image : "user_default.png" %>
               <div class="d-flex align-items-center">
                 <%= image_tag image , class: "rounded-circle", size: "60x60" %>
                 <div class="d-flex align-items-start flex-column justify-content-start"> <%# flex-colmunは縦並び %>
-                  <div class="px-0">
+                  <div class="px-1">
                     <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
                       <strong><%= tweet.user.name %>&nbsp;</strong>
                     <% end %>

--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="co-12 col-lg-8 offset-lg-2">
       <div class="card">
-       <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+       <% image = @tweet.user.profile.present? && @tweet.user.profile.image.present? ? @tweet.user.profile&.image : "user_default.png" %>
         <div class="d-flex align-items-center">
           <%= image_tag image , class: "rounded-circle", size: "60x60" %>
           <div class="d-flex align-items-start justify-content-start">
@@ -59,7 +59,7 @@
               </div><!-- /.modal-content -->
             </div><!-- /.modal-dialog -->
           </div><!-- /.modal -->
-          <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+          <% image = comment.user.profile.present? && comment.user.profile.image.present? ? comment.user.profile&.image : "user_default.png" %>
           <div class="comment-contents">
             <div class="comment-header d-flex align-items-center">
               <%= image_tag image , class: "rounded-circle", size: "30x30" %>


### PR DESCRIPTION
### つぶやき機能 ユーザーのプロフィール画像が正しく表示されるように実装
プロフィール画像がcurrent_userの画像になっていたため修正。
- 修正前の画面イメージ
    https://trello.com/c/qrmVNv27/218-%E3%81%A4%E3%81%B6%E3%82%84%E3%81%8D%E6%A9%9F%E8%83%BD-%E3%83%97%E3%83%AD%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E7%94%BB%E5%83%8F%E3%81%8C%E6%AD%A3%E3%81%97%E3%81%8F%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%81%AA%E3%81%84%E3%80%82fixbug-tweets-profile-image
- 修正後の画面イメージ
    https://docs.google.com/spreadsheets/d/1wyHCk7f8H8fNYrlQjk6BYKWwLlE48g8yO1V-j9Oquxs/edit#gid=0

確認お願いします。