### PR TITLE
登録済みのプロフィールが消える、3点リーダー編集ボタンが機能しないバグを修正

### DIFF
--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -32,7 +32,7 @@ module Users
       @profile = current_user.build_profile(profile_params)
       if @profile.save
         @profile.user.update(profile_params[:user_attributes])
-        redirect_to users_profiles_path, notice: 'プロフィール情報の入力が完了しました'        
+        redirect_to users_profiles_path, notice: 'プロフィール情報の入力が完了しました'
       else
         render :new
       end
@@ -79,7 +79,8 @@ module Users
 
     def profile_params
       params.require(:profile).permit(
-        :name, :purpose, :image, :created_at, :learning_start, :birthday, :gender, user_attributes: [:name]
+        :name, :image, :learning_start, :birthday, :gender, :purpose,
+        user_attributes: %i[id name]
       ).merge(user_id: current_user.id)
     end
   end

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -23,7 +23,7 @@ module Users
     end
 
     def edit
-      if @user != @current_user
+      if @profile.id != current_user.profile.id
         redirect_to users_profiles_path, notice: '編集権限がありません'
       end
     end
@@ -79,7 +79,7 @@ module Users
 
     def profile_params
       params.require(:profile).permit(
-        :purpose, :image, :created_at, :learning_start, :birthday, :gender, user_attributes: [:name]
+        :name, :purpose, :image, :created_at, :learning_start, :birthday, :gender, user_attributes: [:name]
       ).merge(user_id: current_user.id)
     end
   end

--- a/app/javascript/stylesheets/users/custom.scss
+++ b/app/javascript/stylesheets/users/custom.scss
@@ -16,7 +16,7 @@ body {
 }
 
 .profile-indent-name{
-  padding-left:6.9em;
+  padding-left: 9.5em;
 }
 
 .profile-indent-birthday{

--- a/app/views/layouts/users/_header.html.erb
+++ b/app/views/layouts/users/_header.html.erb
@@ -25,9 +25,15 @@
           </li> 
         <% elsif request.fullpath == "/users/profiles" %>
           <li class="nav-item">
+          <% if current_user.profile.nil? %>
             <%= link_to new_users_profile_path, class: "nav-link", method: :get do %>
               <p>プロフィール投稿</p>
             <% end %>
+          <% else %>
+            <%= link_to edit_users_profile_path(current_user.profile.id), class: "nav-link", method: :get do %>
+              <p>プロフィールを編集</p>
+            <% end %>
+          <% end %>
           </li>
         <% elsif request.fullpath == "/users/posts" %>
           <li class="nav-item">

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -27,7 +27,9 @@
             <i class="fas fa-user"></i>
             <label class="profile-indent">名前</label>
             <label class="profile-indent-gender">
-              <%= f.text_field :name, class: 'form-control' %>
+              <%= f.fields_for :user do |user_fields| %>
+                <%= user_fields.text_field :name, class: "form-control", style: "width:300px" %>
+              <% end %>
             </label>
           </div>
         </div>
@@ -36,7 +38,7 @@
             <i class="fas fa-gift"></i>
             <label class="profile-indent">誕生日</label>
             <label class="profile-indent-birthday">
-              <%= f.date_field :birthday, use_month_numbers: true , class: 'form-control', style:"width:300px"%>
+              <%= f.date_field :birthday, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
             </label>
           </div>
         </div>
@@ -45,7 +47,7 @@
             <i class="fas fa-heart"></i>
             <label class="profile-indent">性別</label>
             <label class="profile-indent-gender">
-              <%= f.select :gender, Profile.genders_i18n.keys.map {|k| [Profile.genders_i18n[k], k]}, {include_blank: '選択してください'}, class: 'form-control', style:"width:300px" %>
+              <%= f.select :gender, Profile.genders_i18n.keys.map {|k| [Profile.genders_i18n[k], k]}, {include_blank: '選択してください'}, class: 'form-control', style: "width:300px" %>
             </label>
           </div>
         </div>
@@ -54,7 +56,7 @@
             <i class="fas fa-book-open"></i>
             <label class="profile-indent">プログラミング学習開始日</label>
             <label class="profile-indent-input">
-              <%= f.date_field :learning_start, use_month_numbers: true , class: 'form-control', style:"width:300px" %>
+              <%= f.date_field :learning_start, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
             </label>
           </div>
         </div>
@@ -63,15 +65,14 @@
             <i class="fas fa-flag"></i>
             <label class="profile-indent">プログラミング学習の目的</label>
             <label class="profile-indent-purpose">
-              <%= f.text_area :purpose, class: "form-control", style:"width:300px" %>
+              <%= f.text_area :purpose, class: "form-control", style: "width:300px" %>
             </label>
           </div>
         </div>
       </div>
       <div class="text-center form-group">
-        <%= f.submit "更新", class: "btn btn-primary" , style:"width:150px" %>
+        <%= f.submit "更新", class: "btn btn-primary" , style: "width:150px" %>
       </div>
     <% end %>
   </div>
 </div>
-

--- a/app/views/users/profiles/new.html.erb
+++ b/app/views/users/profiles/new.html.erb
@@ -14,61 +14,64 @@
           <div class="form-inline">
             <i class="fas fa-user"></i>
             <label class="profile-indent">名前</label>
-            <%= f.fields_for :user do |user_fields| %>
-              <%= user_fields.text_field :name, class: "form-control", style:"width:300px" %>
-            <% end %>
+            <label class="profile-indent-name">
+              <%= f.fields_for :user do |user_fields| %>
+                <%= user_fields.text_field :name, class: "form-control", style: "width:300px" %>
+              <% end %>
+            </label>
           </div>
         </div>
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-gift"></i>
-              <label class="profile-indent">誕生日</label>
-                <label class="profile-indent-birthday">
-                  <%= f.date_field :birthday, use_month_numbers: true , class: 'form-control', style:"width:300px"%>
-                </label>
+            <label class="profile-indent">誕生日</label>
+            <label class="profile-indent-birthday">
+              <%= f.date_field :birthday, use_month_numbers: true , class: 'form-control', style: "width:300px"%>
+            </label>
           </div>
         </div>
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-heart"></i>
-              <label class="profile-indent">性別</label>
-                <label class="profile-indent-gender">
-                  <%= f.select :gender, Profile.genders_i18n.keys.map {|k| [Profile.genders_i18n[k], k]}, {include_blank: '選択してください'}, class: 'form-control', style:"width:300px" %>
-                </label>
+            <label class="profile-indent">性別</label>
+            <label class="profile-indent-gender">
+              <%= f.select :gender, Profile.genders_i18n.keys.map {|k| [Profile.genders_i18n[k], k]}, {include_blank: '選択してください'}, class: 'form-control', style: "width:300px" %>
+            </label>
           </div>
         </div>
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-book-open"></i>
-              <label class="profile-indent">プログラミング学習開始日</label>
-                <label class="profile-indent-input">
-                  <%= f.date_field :learning_start, use_month_numbers: true , class: 'form-control', style:"width:300px" %>
-                </label>
+            <label class="profile-indent">プログラミング学習開始日</label>
+            <label class="profile-indent-input">
+              <%= f.date_field :learning_start, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
+            </label>
           </div>
         </div>
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-flag"></i>
-              <label class="profile-indent">プログラミング学習の目的</label>
-                <label class="profile-indent-purpose">
-                  <%= f.text_area :purpose, class: "form-control", style:"width:300px" %>
-                </label>
+            <label class="profile-indent">プログラミング学習の目的</label>
+            <label class="profile-indent-purpose">
+              <%= f.text_area :purpose, class: "form-control", style: "width:300px" %>
+            </label>
           </div>
         </div>
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-image"></i>
-              <label class="profile-indent">プロフィール画像</label>
-                <label class="profile-indent-image">
-                  <%= f.file_field :image %>
-                </label>
+            <label class="profile-indent">プロフィール画像</label>
+            <label class="profile-indent-image">
+              <%= f.file_field :image %>
+            </label>
           </div>
         </div>
-    </div>
+      </div>
       <p class="text-center" style="font-size:13px">※プログラミング学習開始日と、プログラミング学習の目的は必須項目です。</p>
       <div class="text-center form-group">
-        <%= f.submit class: "btn btn-primary" , style:"width:150px"%>
+        <%= f.submit class: "btn btn-primary" , style: "width:150px"%>
       </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -18,7 +18,7 @@
                   </div>
                   <div class="profile-indent text-center">
                     <i class="fas fa-user"></i>
-                    <span><%= @profile.name %></span>
+                    <span><%= @profile.user.name %></span>
                   </div>
                     <hr>
                   <div class="profile-indent" style="padding-left:30px">

--- a/db/migrate/20230614014943_remove_name_from_profiles.rb
+++ b/db/migrate/20230614014943_remove_name_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromProfiles < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :profiles, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_01_122548) do
+ActiveRecord::Schema.define(version: 2023_06_14_014943) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -143,7 +143,6 @@ ActiveRecord::Schema.define(version: 2023_05_01_122548) do
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "name"
     t.integer "learning_history"
     t.string "purpose"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Profileモデルのテスト', type: :model do
 
     it 'is invalid without a purpose' do
       profile = Profile.new(
-        purpose: nil,
+        purpose: nil
       )
       profile.valid?
       expect(profile.errors[:purpose]).to include('を入力してください')
@@ -26,11 +26,6 @@ RSpec.describe 'Profileモデルのテスト', type: :model do
       it '空欄でないこと' do
         profile.purpose = ''
         expect(subject).to eq false
-      end
-
-      it '20文字以下であること' do
-        profile.name = '月収50万円稼ぐrailsエンジニアの田中浩！'
-        expect(profile.valid?).to eq false
       end
     end
 


### PR DESCRIPTION
**PR概要**
以下２点のバグ修正。
- プロフィール登録済みユーザーで、ヘッダ右上のプロフィール投稿ボタンを押すと、新規投稿ページに遷移すると同時に、投稿したはずのプロフデータが消える。
- 3点リーダー編集ボタン押下すると、編集権限がないとエラー表示。

**実装内容**
- ログインユーザーがプロフィール投稿済みなら、「プロフィールを編集」ボタンへ変更。押下後は編集ページへ遷移
- 3点リーダーの編集ボタン押下後、編集ページへ遷移。
- Profileテーブルのnameカラム削除に伴い、profile_spec.rb の profile.name '20文字以下であること'のテストコード部分を削除。

修正後の動画にはユーザー名変更しておりませんが、Usersテーブルのnameカラムを変更できます。

**実装画面スクリーンショットのスプレッドシートのリンク**

https://docs.google.com/spreadsheets/d/1jk1GomJMRloK4zCPtFinvBWzT8vk6fCijXaklKbKdZU/edit#gid=1655146687

**バグ修正前**

https://github.com/nishinotakay/teac-output-new/assets/68493893/b3bf59f7-3d49-47da-a803-7c81a8ea13e1

**バグ修正後**

https://github.com/nishinotakay/teac-output-new/assets/68493893/ada2ac60-a414-48bf-826a-984b782c6c82
