### PR TITLE
動画投稿のseedを追加

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,8 +10,8 @@
 
 50.times do |i|
   user = User.new(
-    email: "test_user#{i}@gmail.com", # sample: test_user1@gmail.com
-    name: "テストuser#{i}",
+    email:    "test_user#{i}@gmail.com", # sample: test_user1@gmail.com
+    name:     "テストuser#{i}",
     password: 'password'
   )
 
@@ -19,14 +19,14 @@
   user.save!
 end
 
-names = %i(生澤智史 菅原靖人 養性光明 元永真広 西野鷹也 江草誠)
-emails = %i(ikezawa@test.com sugawara@test.com yosei@test.com motonaga@test.com nishino@test.com egusa@test.com)
+names = %i[生澤智史 菅原靖人 養性光明 元永真広 西野鷹也 江草誠]
+emails = %i[ikezawa@test.com sugawara@test.com yosei@test.com motonaga@test.com nishino@test.com egusa@test.com]
 
 6.times do |i|
   user = User.new(
-    name: names[i],
-    email: emails[i],
-    password: "password"
+    name:     names[i],
+    email:    emails[i],
+    password: 'password'
   )
 
   user.skip_confirmation! # deviseの確認メールをスキップ
@@ -36,17 +36,17 @@ end
 User.all.each do |u|
   50.times do |i|
     article = u.articles.new(
-      title: "たいとる#{i} author #{u.name}",
+      title:     "たいとる#{i} author #{u.name}",
       sub_title: "さぶたいとる#{i} author #{u.name}",
-      content: "こんてんつ#{i} author #{u.name}"
+      content:   "こんてんつ#{i} author #{u.name}"
     )
     article.save!
   end
 end
 
 manager = Manager.new(
-  email: 'test_manager@gmail.com',
-  name: 'テストmanager1',
+  email:    'test_manager@gmail.com',
+  name:     'テストmanager1',
   password: 'password'
 )
 
@@ -54,10 +54,23 @@ manager.skip_confirmation! # deviseの確認メールをスキップ
 manager.save!
 
 admin = Admin.new(
-  email: 'test_admin@gmail.com',
-  name: 'テストadmin1',
+  email:    'test_admin@gmail.com',
+  name:     'テストadmin1',
   password: 'password'
 )
 
 admin.skip_confirmation! # deviseの確認メールをスキップ
 admin.save!
+
+300.times do
+  user = User.order('RAND()').first
+
+  post = Post.new(
+    title:       'たいとる',
+    body:        'ないよう',
+    youtube_url: 'https://www.youtube.com/watch?v=MQG-xF7bv1I&t=4s', # seedで作った動画見られない。手動は見られる。
+    user:        user
+  )
+
+  post.save!
+end


### PR DESCRIPTION
## 概要
動画投稿のseedがなかったためレスポンシブデザイン化した時にページネーション部分の確認が出来なかったため、動画投稿のseedの記述を追加しました。

・仕様書のページネーション部分(このように実装しようとしていました。)↓
<img width="500" alt="image" src="https://github.com/nishinotakay/teac-output-new/assets/97861380/69a59728-8686-4165-a9ba-8187850f9067">

・画面動画
https://github.com/nishinotakay/teac-output-new/assets/97861380/eab191b6-7c9a-46a5-bc4c-529c82a88032

※　seedで作成された動画は見られない状態となっていますが見られなくても問題ないのでこのままとさせて頂きますm(_ _)m　手動で投稿した動画は見られます。

動作確認して頂ける場合は、
docker-compose run --rm app rails db:migrate:reset　→　docker-compose run --rm app rails db:seed
をお願い致します。