### PR TITLE
remove_tweets_table_column

### DIFF
--- a/db/migrate/20230706064937_remove_coment_from_tweets.rb
+++ b/db/migrate/20230706064937_remove_coment_from_tweets.rb
@@ -1,0 +1,6 @@
+class RemoveComentFromTweets < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :tweets, :coment, :string
+    remove_column :tweets, :good, :string
+  end
+end

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory :tweet do
     post { "MyString" }
-    coment { "MyString" }
-    good { "MyString" }
     user { nil }
   end
 end


### PR DESCRIPTION
### tweetsテーブルから使用していないカラムを削除
テストコードを記述するにあたり、使用していないカラムが存在すると、テストケースを書く際に使用していないカラムを考慮しなければならないため、使用していないカラムを削除します。
また、カラムの削除に伴い`spec/factories/tweets.rb`の記述を変更しました。
今回画面遷移に変更はありませんが、マイグレーションファイルを追加しているので、rails db:migrateの動作確認をお願いします🙇‍♂️

以下chatGPTでのやり取りスクショです。
![スクリーンショット 2023-07-06 16 23 22](https://github.com/nishinotakay/teac-output-new/assets/99413634/58d27d7b-a1ec-48ef-aa9f-8c3dab09ad92)
![スクリーンショット 2023-07-06 16 23 35](https://github.com/nishinotakay/teac-output-new/assets/99413634/55bbaf92-79eb-467a-b584-8cd8a9e18452)

