### PR TITLE
bug/fix-article-sort-filter

### DIFF
--- a/app/controllers/admins/articles_controller.rb
+++ b/app/controllers/admins/articles_controller.rb
@@ -14,11 +14,10 @@ module Admins
         start:    params[:start],
         finish:   params[:finish]
       }
-
+      #binding.pry
       if (@paginate = filter.compact.blank?)
         @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
-      else
-        (@paginate = filter.compact.present?)
+      else(@paginate = filter.compact.present?)
         filter[:order] = params[:order]
         @articles = Article.sort_filter(filter).page(params[:page]).per(30)
       end

--- a/app/controllers/admins/articles_controller.rb
+++ b/app/controllers/admins/articles_controller.rb
@@ -14,17 +14,16 @@ module Admins
         start:    params[:start],
         finish:   params[:finish]
       }
-      #binding.pry
       if (@paginate = filter.compact.blank?)
         @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
-      else(@paginate = filter.compact.present?)
+      else
+        (@paginate = filter.compact.present?)
         filter[:order] = params[:order]
         @articles = Article.sort_filter(filter).page(params[:page]).per(30)
       end
     end
 
-    def show
-    end
+    def show; end
 
     def users_show
       @user = @article.user
@@ -55,8 +54,7 @@ module Admins
       end
     end
 
-    def edit
-    end
+    def edit; end
 
     def users_edit
       @user = @article.user

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -19,7 +19,8 @@ module Users
 
       if (@paginate = filter.compact.blank?)
         @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
-      else (@paginate = filter.compact.present?)
+      else
+        (@paginate = filter.compact.present?)
         filter[:order] = params[:order]
         @articles = Article.sort_filter(filter).page(params[:page]).per(30)
       end

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -8,14 +8,20 @@ module Users
 
     def index
       params[:order] ||= 'DESC'
-      filter = { author: params[:author], title: params[:title], subtitle: params[:subtitle],
-        content: params[:content], start: params[:start].present? ? Time.zone.parse(params[:start]) : nil, 
-        finish: params[:finish].present? ? Time.zone.parse(params[:finish]) : nil }
-      if @paginate = filter.compact.blank?
+      filter = {
+        author:   params[:author],
+        title:    params[:title],
+        subtitle: params[:subtitle],
+        content:  params[:content],
+        start:    params[:start],
+        finish:   params[:finish]
+      }
+
+      if (@paginate = filter.compact.blank?)
         @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
-      else
+      else (@paginate = filter.compact.present?)
         filter[:order] = params[:order]
-        @articles = Article.sort_filter(filter)
+        @articles = Article.sort_filter(filter).page(params[:page]).per(30)
       end
     end
 

--- a/app/controllers/users/dash_boards_controller.rb
+++ b/app/controllers/users/dash_boards_controller.rb
@@ -2,13 +2,21 @@ module Users
   class DashBoardsController < Users::Base
     def index
       params[:order] ||= 'DESC'
-      filter = { author: params[:author], title: params[:title], subtitle: params[:subtitle],
-        content: params[:content], start: params[:start], finish: params[:finish] }
-      if @paginate = filter.compact.blank?
+      filter = {
+        author:   params[:author],
+        title:    params[:title],
+        subtitle: params[:subtitle],
+        content:  params[:content],
+        start:    params[:start],
+        finish:   params[:finish]
+      }
+
+      if (@paginate = filter.compact.blank?)
         @articles = current_user.articles.order(created_at: params[:order]).page(params[:page]).per(30)
       else
+        (@paginate = filter.compact.present?)
         filter[:order] = params[:order]
-        @articles = current_user.articles.sort_filter(filter)
+        @articles = current_user.articles.sort_filter(filter).page(params[:page]).per(30)
       end
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,13 +17,13 @@ class Article < ApplicationRecord
     start = Time.zone.parse(filter[:start].presence || '2022-01-01').beginning_of_day
     finish = Time.zone.parse(filter[:finish].presence || Date.current.to_s).end_of_day
 
-    articles = left_joins(:user, :admin)
+    left_joins(:user, :admin)
               .where(['title LIKE ? AND sub_title LIKE ? AND content LIKE ?',
               "%#{filter[:title]}%", "%#{filter[:subtitle]}%", "%#{filter[:content]}%"])
               .where('articles.created_at BETWEEN ? AND ?', start, finish)
               .where('users.name LIKE :author OR admins.name LIKE :author', author: "%#{filter[:author]}%")
               .order("articles.created_at #{filter[:order]}")
-    articles.presence || []
+              .presence || Article.none
   end
 
   # scriptタグとiframeタグを取り除くメソッド

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -18,17 +18,16 @@ class Article < ApplicationRecord
     finish = Time.zone.parse(filter[:finish].presence || Date.current.to_s).end_of_day
 
     left_joins(:user, :admin)
-              .where(['title LIKE ? AND sub_title LIKE ? AND content LIKE ?',
+      .where(['title LIKE ? AND sub_title LIKE ? AND content LIKE ?',
               "%#{filter[:title]}%", "%#{filter[:subtitle]}%", "%#{filter[:content]}%"])
-              .where('articles.created_at BETWEEN ? AND ?', start, finish)
-              .where('users.name LIKE :author OR admins.name LIKE :author', author: "%#{filter[:author]}%")
-              .order("articles.created_at #{filter[:order]}")
-              .presence || Article.none
+      .where('articles.created_at BETWEEN ? AND ?', start, finish)
+      .where('users.name LIKE :author OR admins.name LIKE :author', author: "%#{filter[:author]}%")
+      .order("articles.created_at #{filter[:order]}")
+      .presence || Article.none
   end
 
   # scriptタグとiframeタグを取り除くメソッド
   def sanitized_content
     self.content.gsub(/<script>.*<\/script>/m, '').gsub(/<iframe[\s\S]*?<\/iframe>/m, '')
   end
-  
 end


### PR DESCRIPTION
**PR概要**
記事の条件検索時、エラー修正（管理者・ユーザー）
ユーザーログイン時、記事条件検索後の遷移先でページネーション実装

**エラー内容**
①管理者ログインの記事一覧にて、データベースに無いワードで条件検索するとエラー発生。
<img width="1440" alt="スクリーンショット 2023-07-14 19 14 06" src="https://github.com/nishinotakay/teac-output-new/assets/68493893/334ef911-892d-4633-a0fd-0a8023a8821c">

②ユーザーログインの記事一覧にて、日付検索するとエラー発生
<img width="1440" alt="スクリーンショット 2023-07-14 17 49 31" src="https://github.com/nishinotakay/teac-output-new/assets/68493893/9c36acbe-15b4-48f3-b2fe-a4ab3a9e46a7">

③ユーザーログインの「記事一覧」、「投稿した記事一覧」画面にて、条件検索後の遷移先でページネーションが機能していない。

**確認手順**

①adminでログイン
管理者ログイントップページ
http://localhost:3000/admins/sign_in

email: 'test_admin@gmail.com',
name: 'テストadmin1',
password: 'password'

記事一覧画面の条件検索にて、データベースに無いワードで検索

②userでログイン
ユーザーログインページ
http://localhost:3000/users/sign_in

email: 'test_user1@gmail.com',
name: 'テストuser1',
password: 'password'

記事一覧画面にて、日付指定して条件検索。

③userでログイン
全記事一覧画面にて、30件以上ヒットするよう条件検索する。例：タイトルフォームに「たいとる」


**実装内容**
①app/models/article.rbのself.sort_filter(filter)メソッドを修正。
エラーの原因
検索結果がnilの場合は空の配列[]を返していた為。ページネーション機能のpageメソッドは空の配列[]では機能しない。
修正後
・[]から Article.none　に変更。
・articlesに代入しなくても機能すると知り、代入なしに変更

②users/articles_controller.rb の indexアクション修正
エラー原因
models/article.rb と users/articles_controller.rbで、Time.zone.parseの実装が被っていたのが原因。
adimin の indexアクションと同様に実装

③pageメソッドがなかったので実装。

**備考**
①のように、戻り値がnilで起きる不具合の対処実装をnilガードと呼ぶそう。かなり詰まってしまい勉強になりました。
私が着手する前から[]の配列が戻り値として記述されていたので、意図があるかもしれない。今後不具合ないか注意する。
