### PR TITLE
テナントCRUD機能実装

### DIFF
--- a/app/controllers/managers/tenants_controller.rb
+++ b/app/controllers/managers/tenants_controller.rb
@@ -41,3 +41,4 @@ module Managers
       end
   end
 end
+

--- a/app/controllers/managers/tenants_controller.rb
+++ b/app/controllers/managers/tenants_controller.rb
@@ -1,8 +1,9 @@
 module Managers
   class TenantsController < Managers::Base
+    before_action :set_tenant, only: %i[show destroy]
 
     def index
-      @tenants = Tenant.all
+      @tenants = Tenant.page(params[:page]).per(30)
     end
 
     def new
@@ -12,20 +13,21 @@ module Managers
     def create
       @tenant = Tenant.new(tenant_params)
       if @tenant.save
-        flash.now[:success] = "#{@tenant.name}を登録しました。"
-        redirect_to :index
+        flash[:notice] = "#{@tenant.name}を登録しました。"
+        redirect_to managers_tenants_url
       else
-        flash.now[:danger] = '登録できませんでした。やり直してください。'
+        flash.now[:notice] = '登録できませんでした。やり直してください。'
         render :new
       end
     end
 
+    def show; end
+
     def destroy
-      @tenant = Tenant.find(params[:id])
       if @tenant.destroy!
-        flash.now[:warning] = "#{@tenant.name}を削除しました。"
+        flash[:notice] = "#{@tenant.name}を削除しました。"
       end
-      render :index
+      redirect_to managers_tenants_url
     end
 
     private
@@ -33,6 +35,9 @@ module Managers
       def tenant_params
         params.require(:tenant).permit(:name)
       end
+
+      def set_tenant
+        @tenant = Tenant.find(params[:id])
+      end
   end
 end
-

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,2 +1,3 @@
 class Tenant < ApplicationRecord
+  validates :name, presence: true, length: { in: 1..20 }
 end

--- a/app/views/layouts/managers/_side.html.erb
+++ b/app/views/layouts/managers/_side.html.erb
@@ -26,7 +26,7 @@
           <% end %>
         </li>
         <li class="nav-item">
-          <%= link_to "#", class:"nav-link", method: :get do %>
+          <%= link_to new_managers_tenant_path, class:"nav-link", method: :get do %>
             <i class="nav-icon far fa-plus-square"></i>
             <p>
               テナント登録

--- a/app/views/layouts/managers/_side.html.erb
+++ b/app/views/layouts/managers/_side.html.erb
@@ -39,3 +39,4 @@
   </div>
   <!-- /.sidebar -->
 </aside>
+

--- a/app/views/managers/tenants/index.html.erb
+++ b/app/views/managers/tenants/index.html.erb
@@ -4,48 +4,40 @@
   <div class="container">
     <div class="row">
       <div class="col-12">
-        <div class="content">
-          <div class="container">
-            <div class="row">
-              <div class="col-12">
-                <% hover = @tenants.present? ? "table-hover" : "" %>
-                <table class="table tenants-table <%= hover %> table-scroll">
-                  <thead>
-                    <tr>
-                      <th class="px-5"><%= Tenant.human_attribute_name(:name) %></th>
-                      <th>　　　</th>
-                      <th class="px-5"><%= Tenant.human_attribute_name(:created_at) %></th>
-                      <th></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <% if hover.present? %>
-                      <% @tenants.each_with_index do |tenant| %>
-                        <tr>
-                          <td class="link-td" onclick='window.location="#"'><%= tenant.name %></td>
-                          <td></td>
-                          <td class="link-td" onclick='window.location="#"'><%= l(tenant.created_at, format: :date) %></td>                  
-                          <td>
-                            <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
-                            <ul class="dropdown-menu">
-                              <li><%= link_to '閲覧', "#", method: :get, class: "nav-link", method: :get %></li>
-                              <li><%= link_to '編集', "#", method: :get, class: "nav-link" %></li>
-                              <li><%= link_to '削除', "#", method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>                    
-                            </ul>
-                          </td>
-                        </tr>
-                      <% end %>
-                    <% else %>
-                      <td colspan='100' class="text-center py-5">テナントの登録はありません。</td>
-                    <% end %>
-                  </tbody>
-                </table>
-                <%= paginate @tenants, theme: 'bootstrap-5' if @paginate %>
-              </div>
-            </div>
-          </div>
-        </div>
+        <% hover = @tenants.present? ? "table-hover" : "" %>
+        <table class="table tenants-table <%= hover %> table-scroll">
+          <thead>
+            <tr>
+              <th class="px-5"><%= Tenant.human_attribute_name(:name) %></th>
+              <th>　　　</th>
+              <th class="px-5"><%= Tenant.human_attribute_name(:created_at) %></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if hover.present? %>
+              <% @tenants.each_with_index do |tenant| %>
+                <tr>
+                  <td class="link-td" onclick='window.location="<%= managers_tenant_path(tenant)%>"'><%= tenant.name %></td>
+                  <td></td>
+                  <td class="link-td" onclick='window.location="<%= managers_tenant_path(tenant)%>"'><%= l(tenant.created_at, format: :date) %></td>                  
+                  <td>
+                    <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
+                    <ul class="dropdown-menu">
+                      <li><%= link_to '閲覧', managers_tenant_path(tenant), method: :get, class: "nav-link", method: :get %></li>
+                      <li><%= link_to '削除', managers_tenant_path(tenant.id), method: :delete, data: {confirm: "#{tenant.name}を削除します。"}, class: "nav-link" %></li>                    
+                    </ul>
+                  </td>
+                </tr>
+              <% end %>
+            <% else %>
+              <td colspan='100' class="text-center py-5">テナントの登録はありません。</td>
+            <% end %>
+          </tbody>
+        </table>
+        <%= paginate @tenants, theme: 'bootstrap-5' %>
       </div>
     </div>
   </div>
- </div> 
+</div>
+

--- a/app/views/managers/tenants/new.html.erb
+++ b/app/views/managers/tenants/new.html.erb
@@ -1,0 +1,26 @@
+<%= javascript_pack_tag "users/profiles" %>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+
+<div class="div-title-form">
+  <div class="card card-outline card-primary">
+    <div class="card-header text-center">
+      <h2>テナントの登録</h2>
+    </div>
+    <br>
+    <%= form_with model: @tenant, url: managers_tenants_path, local: true do |f| %>
+      <div style="padding-left:50px">
+        <div class="form-group">
+          <div class="form-inline">
+            <i class="fas fa-building"></i>
+            <label class="tenant-name">　テナント名　</label>
+              <%= f.text_field :name, class: "tenant-name form-control", style: "width:300px" %>
+          </div>
+        </div>
+        
+      <div class="text-center form-group">
+        <%= f.submit "登録", class: "btn btn-primary" , style: "width:150px" %>
+        <%= link_to 'キャンセル', :back, class: "btn btn-outline-dark" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/managers/tenants/new.html.erb
+++ b/app/views/managers/tenants/new.html.erb
@@ -13,9 +13,10 @@
           <div class="form-inline">
             <i class="fas fa-building"></i>
             <label class="tenant-name">　テナント名　</label>
-              <%= f.text_field :name, class: "tenant-name form-control", style: "width:300px" %>
+            <%= f.text_field :name, class: "tenant-name form-control", style: "width:300px" %>
           </div>
         </div>
+      </div>
         
       <div class="text-center form-group">
         <%= f.submit "登録", class: "btn btn-primary" , style: "width:150px" %>

--- a/app/views/managers/tenants/show.html.erb
+++ b/app/views/managers/tenants/show.html.erb
@@ -1,0 +1,23 @@
+<%= javascript_pack_tag "users/profiles" %>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+
+<div class="div-title-form">
+  <div class="card card-outline card-primary">
+    <div class="card-header text-center">
+      <h2><%= "#{@tenant.name}の詳細" %></h2>
+    </div>
+    <br>
+      <div style="padding-left:50px">
+        <div class="form-group">
+          <div class="form-inline">
+            <i class="fas fa-building"></i>
+            <label class="tenant-name">　テナント名：：</label>
+              <%= "#{@tenant.name}" %>
+          </div>
+        </div>
+        
+      <div class="text-center form-group">
+        <%= link_to '戻る', :back, class: "btn btn-outline-dark" %>
+      </div>
+  </div>
+</div>

--- a/app/views/managers/tenants/show.html.erb
+++ b/app/views/managers/tenants/show.html.erb
@@ -7,17 +7,19 @@
       <h2><%= "#{@tenant.name}の詳細" %></h2>
     </div>
     <br>
-      <div style="padding-left:50px">
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-building"></i>
-            <label class="tenant-name">　テナント名：　</label>
-              <%= "#{@tenant.name}" %>
-          </div>
+    <div style="padding-left:50px">
+      <div class="form-group">
+        <div class="form-inline">
+          <i class="fas fa-building"></i>
+          <label class="tenant-name">　テナント名：　</label>
+          <%= "#{@tenant.name}" %>
         </div>
-        
-      <div class="text-center form-group">
-        <%= link_to '戻る', :back, class: "btn btn-outline-dark" %>
       </div>
+    </div>
+        
+    <div class="text-center form-group">
+      <%= link_to '戻る', :back, class: "btn btn-outline-dark" %>
+    </div>
   </div>
 </div>
+

--- a/app/views/managers/tenants/show.html.erb
+++ b/app/views/managers/tenants/show.html.erb
@@ -11,7 +11,7 @@
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-building"></i>
-            <label class="tenant-name">　テナント名：：</label>
+            <label class="tenant-name">　テナント名：　</label>
               <%= "#{@tenant.name}" %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,7 @@ Rails.application.routes.draw do
   }
 
   namespace :managers do
-    resources :tenants, only: [:index, :new, :create, :destroy]
+    resources :tenants, only: [:index, :show, :new, :create, :destroy]
   end
   # =================================================================
 

--- a/db/migrate/20230717063138_change_column_name_in_tenants.rb
+++ b/db/migrate/20230717063138_change_column_name_in_tenants.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameInTenants < ActiveRecord::Migration[6.1]
+  def change
+    change_column :tenants, :name, :string, null: false, limit: 20
+  end
+end


### PR DESCRIPTION
**PR概要**
テナントの登録・詳細・削除機能の実装(編集は不可）。
①テナントは名前の登録のみ。２０文字以内の制限をかけています（マイグレーションファイル作成）。
②テナント一覧ページにてページネーション機能追加。（３０件/page）
③index.html.erbの不要なdiv要素を削除。

**確認手順**
managers/sign_in にて　test_manager@gmail.com　でログイン。
登録はサイドバーのメニューでできます。
詳細と削除はテナント行の三点リーダにて可能。
テナント名のクリックでも詳細に遷移可能。

以上、確認お願いいたします。

仕様書
https://docs.google.com/spreadsheets/d/1dQyO_o_BXXx1Nfe1HcXqXcoLxleJWLgOTgmepsnLsHc/edit#gid=529233826

<img width="1439" alt="スクリーンショット 2023-07-18 17 15 47" src="https://github.com/nishinotakay/teac-output-new/assets/100989880/35df0804-063d-46c1-9cf2-47d74f312e43">

<img width="1215" alt="スクリーンショット 2023-07-18 17 48 50" src="https://github.com/nishinotakay/teac-output-new/assets/100989880/96ebec25-b49a-4796-ac7a-617e7efc9653">


