### PR TITLE
[ WIP ] Fix/edit_models_article_spec

### DIFF
--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -2,7 +2,8 @@
 
 FactoryBot.define do
   factory :admin do
-    sequence(:email) { |n| "admin#{n}@example.com" }
+    name { '管理者' }
+    email { Faker::Internet.email }
     password { 'password' }
     password_confirmation { 'password' }
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :article do
-    sequence(:title, 'railsエンジニアのブログ記事_1')
-    sequence(:sub_title, 'railsエンジニアのためのブログ記事を書きました！_1')
-    sequence(:content, 'MyText_1')
+    sequence(:title) { |n| "railsエンジニアのブログ記事_#{n}" }
+    sequence(:sub_title) { |n| "railsエンジニアのためのブログ記事を書きました！_#{n}" }
+    sequence(:content) { |n| "MyText_#{n}" }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,22 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Article, type: :model do
-  #let(:user_a) { build(:user, :a, confirmed_at: Date.today) }
+  # let(:user_a) { build(:user, :a, confirmed_at: Date.today) }
   let(:user) { create(:user, confirmed_at: Date.today) }
   let(:user_article) { build(:article, user: user) }
   let(:admin) { create(:admin, confirmed_at: Date.today) }
   let(:admin_article) { build(:article, admin: admin) }
-  #let(:user) { create(:user, confirmed_at: Date.today) }
-  #let!(:user_articles) { create_list(:article, 10, user: user) }
+  # let(:user) { create(:user, confirmed_at: Date.today) }
+  # let!(:user_articles) { create_list(:article, 10, user: user) }
 
   describe '条件検索について' do
     subject { user_articles }
-    before do # before(:each) do
+
+    before(:each) do # before(:each) do
       # 10個の記事を作成します
       10.times { create(:article, user: user) } # FactoryBot省略可
     end
 
-    context "正常系" do
+    context '正常系' do
       it '条件を満たす記事を抽出できる' do # 10番目に生成された記事を条件検索します。_10
         filter = {
           start:    '2023-01-01',
@@ -41,17 +42,16 @@ RSpec.describe Article, type: :model do
         }
         articles = Article.sort_filter(filter)
         expect(articles.count).to eq(10)
-          # 必要に応じて他の期待を設定します。例えば、特定の記事が結果に含まれていること、または含まれていないことなど
       end
     end
 
-    context "異常系" do
+    context '異常系' do
       it '条件を満たすタイトルが存在しない場合は空のリストが返る' do
         filter = { title: '存在しないタイトル', order: 'ASC' }
         articles = Article.sort_filter(filter)
         expect(articles).to be_empty # be_falsy では×
       end
-      #binding.pry
+
       it 'フォーム未入力の場合、全ての記事が抽出される' do
         filter = { title: '', sub_title: '', content: '', order: 'ASC' }
         articles = Article.sort_filter(filter)
@@ -62,15 +62,14 @@ RSpec.describe Article, type: :model do
 
   # 西野さんから文字列ver
   shared_examples '投稿テスト' do |user_type|
-
     user_type_jp = {
-    'user' => 'ユーザー',
-    'admin' => '管理者'
+      'user'  => 'ユーザー',
+      'admin' => '管理者'
     }
 
     context "#{user_type_jp[user_type]}が記事を投稿する場合" do
-
       subject { send("#{user_type}_article") }
+
       it_behaves_like '正常な記事投稿について'
       it_behaves_like 'タイトルについて'
       it_behaves_like 'サブタイトルについて'

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Article, type: :model do
-  let(:user_a) { build(:user, :a, confirmed_at: Date.today) }
-  let(:user_article) { build(:article, user: user_a) }
+  #let(:user_a) { build(:user, :a, confirmed_at: Date.today) }
+  let(:user) { create(:user, confirmed_at: Date.today) }
+  let(:user_article) { build(:article, user: user) }
   let(:admin) { create(:admin, confirmed_at: Date.today) }
   let(:admin_article) { build(:article, admin: admin) }
-  let(:user) { create(:user, confirmed_at: Date.today) }
+  #let(:user) { create(:user, confirmed_at: Date.today) }
   #let!(:user_articles) { create_list(:article, 10, user: user) }
 
   describe '条件検索について' do
@@ -59,21 +60,24 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  # ユーザーと管理者動的にしてないver
-  RSpec.shared_examples '記事投稿について' do
-    it_behaves_like '正常な記事投稿について'
-    it_behaves_like 'タイトルについて'
-    it_behaves_like 'サブタイトルについて'
-    it_behaves_like '本文について'
+  # 西野さんから文字列ver
+  shared_examples '投稿テスト' do |user_type|
+
+    user_type_jp = {
+    'user' => 'ユーザー',
+    'admin' => '管理者'
+    }
+
+    context "#{user_type_jp[user_type]}が記事を投稿する場合" do
+
+      subject { send("#{user_type}_article") }
+      it_behaves_like '正常な記事投稿について'
+      it_behaves_like 'タイトルについて'
+      it_behaves_like 'サブタイトルについて'
+      it_behaves_like '本文について'
+    end
   end
-  
-  context 'ユーザーが記事を投稿する場合' do
-    subject { user_article }
-    it_behaves_like '記事投稿について'
-  end
-  
-  context '管理者が記事を投稿する場合' do
-    subject { admin_article }
-    it_behaves_like '記事投稿について'
-  end
+
+  include_examples '投稿テスト', 'user'
+  include_examples '投稿テスト', 'admin'
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -59,24 +59,25 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  # chatGPT
+  # 西野さんから文字列ver
   shared_examples '投稿テスト' do |user_type|
 
     user_type_jp = {
-      user: 'ユーザー',
-      admin: '管理者'
+    'user' => 'ユーザー',
+    'admin' => '管理者'
     }
-  
+
+
     context "#{user_type_jp[user_type]}が記事を投稿する場合" do
+
       subject { send("#{user_type}_article") }
-  
       it_behaves_like '正常な記事投稿について'
       it_behaves_like 'タイトルについて'
       it_behaves_like 'サブタイトルについて'
       it_behaves_like '本文について'
     end
   end
-  
-  include_examples '投稿テスト', :user
-  include_examples '投稿テスト', :admin
+
+  include_examples '投稿テスト', 'user'
+  include_examples '投稿テスト', 'admin'
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -59,25 +59,21 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  # 西野さんから文字列ver
-  shared_examples '投稿テスト' do |user_type|
-
-    user_type_jp = {
-    'user' => 'ユーザー',
-    'admin' => '管理者'
-    }
-
-
-    context "#{user_type_jp[user_type]}が記事を投稿する場合" do
-
-      subject { send("#{user_type}_article") }
-      it_behaves_like '正常な記事投稿について'
-      it_behaves_like 'タイトルについて'
-      it_behaves_like 'サブタイトルについて'
-      it_behaves_like '本文について'
-    end
+  # ユーザーと管理者動的にしてないver
+  RSpec.shared_examples '記事投稿について' do
+    it_behaves_like '正常な記事投稿について'
+    it_behaves_like 'タイトルについて'
+    it_behaves_like 'サブタイトルについて'
+    it_behaves_like '本文について'
   end
-
-  include_examples '投稿テスト', 'user'
-  include_examples '投稿テスト', 'admin'
+  
+  context 'ユーザーが記事を投稿する場合' do
+    subject { user_article }
+    it_behaves_like '記事投稿について'
+  end
+  
+  context '管理者が記事を投稿する場合' do
+    subject { admin_article }
+    it_behaves_like '記事投稿について'
+  end
 end

--- a/spec/support/concerns/common_module.rb
+++ b/spec/support/concerns/common_module.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.shared_examples '正常な記事投稿について' do # RSpecの記述無しでも可
+  it 'バリデーションが通ること' do
+    expect(subject).to be_valid
+  end
+end
+
+RSpec.shared_examples 'タイトルについて' do
+  context '存在しない場合' do
+    before :each do # itの前に実行
+      subject.title = nil
+    end
+
+    it 'バリデーションに落ちること' do
+      expect(subject).to be_invalid
+    end
+
+    it 'バリデーションのエラーが正しいこと' do
+      subject.valid?
+      expect(subject.errors.full_messages).to include('タイトルを入力してください')
+    end
+  end
+
+  context '文字数が40文字の場合' do
+    before :each do
+      subject.title = 'a' * 40
+    end
+
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+  end
+
+  context '文字数が41文字の場合' do
+    before :each do
+      subject.title = 'a' * 41
+    end
+
+    it 'バリデーションに落ちること' do
+      expect(subject).to be_invalid
+    end
+
+    it 'バリデーションのエラーが正しいこと' do
+      subject.valid?
+      expect(subject.errors.full_messages).to include('タイトルは40文字以内で入力してください')
+    end
+  end
+end
+
+RSpec.shared_examples 'サブタイトルについて' do
+  context '存在しない場合' do
+    before :each do
+      subject.sub_title = nil
+    end
+    
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+  end
+  
+  context '文字数が50文字の場合' do
+    before :each do
+      subject.sub_title = 'a' * 50
+    end
+    
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+  end
+  
+  context '文字数が51文字の場合' do
+    before :each do
+      subject.sub_title = 'a' * 51
+    end
+    
+    it 'バリデーションに落ちること' do
+      expect(subject).to be_invalid
+    end
+    
+    it 'バリデーションのエラーが正しいこと' do
+      subject.valid?
+      expect(subject.errors.full_messages).to include('サブタイトルは50文字以内で入力してください')
+    end
+  end
+end
+
+RSpec.shared_examples '本文について' do
+  context '存在しない場合' do
+    before :each do
+      subject.content = nil
+    end
+    
+    it 'バリデーションに落ちること' do
+      expect(subject).to be_invalid
+    end
+    
+    it 'バリデーションのエラーが正しいこと' do
+      subject.valid?
+      expect(subject.errors.full_messages).to include('本文を入力してください')
+    end
+  end
+end

--- a/spec/support/concerns/common_module.rb
+++ b/spec/support/concerns/common_module.rb
@@ -53,31 +53,31 @@ RSpec.shared_examples 'サブタイトルについて' do
     before :each do
       subject.sub_title = nil
     end
-    
+
     it 'バリデーションが通ること' do
       expect(subject).to be_valid
     end
   end
-  
+
   context '文字数が50文字の場合' do
     before :each do
       subject.sub_title = 'a' * 50
     end
-    
+
     it 'バリデーションが通ること' do
       expect(subject).to be_valid
     end
   end
-  
+
   context '文字数が51文字の場合' do
     before :each do
       subject.sub_title = 'a' * 51
     end
-    
+
     it 'バリデーションに落ちること' do
       expect(subject).to be_invalid
     end
-    
+
     it 'バリデーションのエラーが正しいこと' do
       subject.valid?
       expect(subject.errors.full_messages).to include('サブタイトルは50文字以内で入力してください')
@@ -90,11 +90,11 @@ RSpec.shared_examples '本文について' do
     before :each do
       subject.content = nil
     end
-    
+
     it 'バリデーションに落ちること' do
       expect(subject).to be_invalid
     end
-    
+
     it 'バリデーションのエラーが正しいこと' do
       subject.valid?
       expect(subject.errors.full_messages).to include('本文を入力してください')


### PR DESCRIPTION
**PR概要**
実装途中です。WIP としてPR致します。
spec/models/article_spec.rb　を編集、共通のテストファイルを作成。

**実装内容**
記事投稿のモデルテストを実装しました。
内容は、管理者、ユーザーが記事を投稿した場合の、バリデーションテスト、フィルター機能テストです。
共通の処理をまとめてspec/support/concerns/common_module.rbに記述しております。
勉強中のためコメントアウト多いです、すみません（^人^;）

**悩んでいること**
どこまでテストパターンを実装すべきか分からない。例えば、検索フォームに２つ入力してヒットするか、3つ入力、4つ入力、5つ入力パターン等も作るべきか。考えすぎだろうか。

本日2023/07/19 のMTGでもご説明します。
他、テストパターンがあればご意見頂きたいです🙇‍♂️
問題なければPRへ変更致します。

**確認方法**
bin/docker/bundle/exec rspec spec/models/article_spec.rb

rspec(個別実行):例 spec/models/article_spec.rbの17行目
bin/docker/bundle/exec rspec spec/models/article_spec.rb:17