### PR TITLE
マネージャー編集画面レイアウト修正

### DIFF
--- a/app/controllers/managers/registrations_controller.rb
+++ b/app/controllers/managers/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 module Managers
   class RegistrationsController < Devise::RegistrationsController
-    layout 'users_auth'
+    layout 'managers'
     # before_action :configure_sign_up_params, only: [:create]
     # before_action :configure_account_update_params, only: [:update]
 

--- a/app/javascript/stylesheets/managers/custom.scss
+++ b/app/javascript/stylesheets/managers/custom.scss
@@ -40,7 +40,12 @@ body {
   background-color: #e9ecef;
 }
 
-.manager-edit {
+// マネージャー編集 //
+
+.btn-manager--edit {
   text-align: center;
 }
 
+.manager-account-edit {
+  height: 300px;
+}

--- a/app/views/managers/profiles/managers_show.html.erb
+++ b/app/views/managers/profiles/managers_show.html.erb
@@ -21,12 +21,12 @@
                   </div>
                   <hr>
                   <div class="profile-indent text-center">
-                    <i class="fas fa-user"></i>
+                    <i class="fas fa-envelope"></i>
                     <span><%= current_manager.email %></span>
                   </div>
                   <hr style="height:0.5px">
                 </div>
-                <div class="manager-edit">
+                <div class="btn-manager--edit">
                   <%= link_to "編集する", edit_manager_registration_path, class: "btn btn-primary" %>
                 </div>   
               </div>

--- a/app/views/managers/registrations/edit.html.erb
+++ b/app/views/managers/registrations/edit.html.erb
@@ -9,7 +9,7 @@
     <br>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <div style="padding-left:100px">
-        <table class="manager-account-edit", height="200">
+        <table class="manager-account-edit">
           <tr>
             <th><i class="fas fa-user"></i></th>
             <th class="manager-name">マネージャー名</th>

--- a/app/views/managers/registrations/edit.html.erb
+++ b/app/views/managers/registrations/edit.html.erb
@@ -1,65 +1,58 @@
-<h2><%= t('.title', resource: resource.model_name.human) %></h2>
+<%= javascript_pack_tag "users/profiles" %>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 
-<div class="register-box">
+<div class="div-title-form">
   <div class="card card-outline card-primary">
     <div class="card-header text-center">
-      <a href="" class="h2"><b>TecPutt</a>
+      <h2>マネージャーアカウントの編集</h2>
     </div>
-    <div class="card-body1">
-      <p class="login-box-msg">アカウントの編集を行えます。</p>
-
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-        <div class="input-group mb-3">
-          <%= f.text_field :name, autofocus: true, class:"form-control", placeholder:"名前（フルネーム）" %>
-          <div class="input-group-append">
-            <div class="input-group-text">
-              <span class="fas fa-user"></span>
-            </div>
-          </div>
-        </div>
-        <div class="input-group mb-3">
-          <%= f.email_field :email, autocomplete: "email", class:"form-control", placeholder:"メールアドレス", required: true %>
-          <div class="input-group-append">
-            <div class="input-group-text">
-              <span class="fas fa-envelope"></span>
-            </div>
-          </div>
-        </div>
-        <div class="input-group mb-3">
-          
-          <%= f.password_field :password, autocomplete: "new-password", class:"form-control", placeholder:"変更後パスワード(変更したい場合)" %>
-          
-          <div class="input-group-append">
-            <div class="input-group-text">
-              <span class="fas fa-lock"></span>
-            </div>
-          </div>
-        </div>
-        <div class="input-group mb-3">
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control", placeholder:"変更後パスワード確認用" %>
-          <div class="input-group-append">
-            <div class="input-group-text">
-              <span class="fas fa-lock"></span>
-            </div>
-          </div>
-        </div>
-        <div class="input-group mb-3">
-          <%= f.password_field :current_password, autocomplete: "new-password", class:"form-control", placeholder:"現在のパスワード（必須）", required: true %>
-          <div class="input-group-append">
-            <div class="input-group-text">
-              <span class="fas fa-lock"></span>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <%= f.submit t('.update'), class:"btn btn-primary btn-block" %>
-          </div>
-        </div>
-      <% end %>
+    <br>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <div style="padding-left:100px">
+        <table class="manager-account-edit", height="200">
+          <tr>
+            <th><i class="fas fa-user"></i></th>
+            <th class="manager-name">マネージャー名</th>
+            <td>
+              <%= f.text_field :name, autofocus: true, class:"form-control", style: "width:350px" %>
+            </td>
+          </tr>
+          <tr>
+            <th><i class="fas fa-envelope"></i></th>
+            <th class="manager-email">メールアドレス</th>
+            <td>
+              <%= f.email_field :email, autocomplete: "email", class:"form-control", required: true, style: "width:350px" %>
+            </td>
+          </tr>
+          <tr>
+            <th><i class="fas fa-lock"></i></th>
+            <th class="manager-password">現在のパスワード（必ず入力してください）</th>
+            <td>
+              <%= f.password_field :current_password, autocomplete: "new-password", class:"form-control", required: true, style: "width:350px" %>
+            </td>
+          </tr>
+          <tr>
+            <th><i class="fas fa-lock"></i></th>
+            <th class="manager-password">新パスワード（変更したい場合）</th>
+            <td>
+              <%= f.password_field :password, autocomplete: "new-password", class:"form-control", style: "width:350px" %>
+            </td>
+          </tr>
+          <tr>
+            <th><i class="fas fa-lock"></i></th>
+            <th class="manager-password">新パスワード（確認用）</th>
+            <td>
+              <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control", style: "width:350px" %>
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="btn-manager--edit">
+        <%= f.submit t('.update'), class:"btn btn-primary" %>
+      </div>
+    <% end %>
+    <div style="padding-left:100px">
+      <%= link_to "戻る", managers_show_managers_profiles_path %>
     </div>
-  </div>
-  <div>
-    <%= link_to "戻る", managers_show_managers_profiles_path %>
   </div>
 </div>


### PR DESCRIPTION
**PR概要**
①マネージャー編集画面レイアウトを修正しました。
- 現在のパスワード入力欄を新パスワードの上に移動
- 編集画面のレイアウトを全体的に修正しました。

②詳細画面のメールアドレスのアイコンを修正

**確認手順**
managers/sign_in　で　test_manager@gmail.com　でログイン
右上アイコンの詳細画面ボタンより詳細画面を確認。
編集ボタンよりアカウント編集画面を確認。

以上、よろしくお願いします。
<img width="580" alt="スクリーンショット 2023-07-30 13 12 56" src="https://github.com/nishinotakay/teac-output-new/assets/100989880/eace08b6-f758-4b62-ad31-fffaea94c161">

<img width="1461" alt="スクリーンショット 2023-07-30 13 12 46" src="https://github.com/nishinotakay/teac-output-new/assets/100989880/634ce54f-3350-421f-ac05-9a9cea03a0e9">

