### PR TITLE
Bug/profile update

### DIFF
--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -2,7 +2,7 @@ module Users
   class ProfilesController < Users::Base
     require 'date'
     before_action :authenticate_user!, only: %i[new create edit update destroy]
-    before_action :find_profile, only: %i[show double_registration edit update destroy]
+    before_action :find_profile, only: %i[show edit update destroy]
     # before_action :double_registration, only: %i[create]
 
     def index
@@ -33,15 +33,15 @@ module Users
       @profile = current_user.build_profile(profile_params)
       if @profile.save
         @profile.user.update(profile_params[:user_attributes])
-        redirect_to users_profiles_path, notice: 'プロフィール情報の入力が完了しました'
+        redirect_to users_profile_path(current_user.profile), notice: 'プロフィールを作成しました'
       else
         render :new
       end
     end
-
+    
     def update
       if @profile.update(profile_params)
-        redirect_to users_profile_path, notice: 'プロフィール情報の更新が完了しました'
+        redirect_to users_profile_path, notice: 'プロフィール情報を更新しました'
       else
         render :edit
       end
@@ -62,21 +62,7 @@ module Users
 
     def find_profile
       @profile = Profile.find(params[:id])
-      # if @profile
-      #   # binding.pry
-      #   redirect_to users_profiles_path, notice: 'プロフィール情報は入力済です'
-      # else
-      # end
     end
-
-    # def double_registration
-    #   # @profile = Profile.find(params[:id])
-    #   if @profile.present?
-    #     redirect_to users_profiles_path, notice: 'プロフィール情報は入力済です'
-    #   else
-    #     # render :show
-    #   end
-    # end
 
     def profile_params
       params.require(:profile).permit(

--- a/app/views/layouts/users/_header.html.erb
+++ b/app/views/layouts/users/_header.html.erb
@@ -24,17 +24,19 @@
             <% end %>
           </li> 
         <% elsif request.fullpath == "/users/profiles" %>
-          <li class="nav-item">
-          <% if current_user.profile.nil? %>
-            <%= link_to new_users_profile_path, class: "nav-link", method: :get do %>
-              <p>プロフィール投稿</p>
-            <% end %>
+          <% if current_user.profile&.id.present? %>
+            <li class="nav-item">
+              <%= link_to edit_users_profile_path(current_user.profile), class: "nav-link", method: :get do %>
+                <p>プロフィールを編集</p>
+              <% end %>
+            </li>
           <% else %>
-            <%= link_to edit_users_profile_path(current_user.profile.id), class: "nav-link", method: :get do %>
-              <p>プロフィールを編集</p>
-            <% end %>
+            <li class="nav-item">
+              <%= link_to new_users_profile_path, class: "nav-link", method: :get do %>
+                <p>プロフィール投稿</p>
+              <% end %>
+            </li>
           <% end %>
-          </li>
         <% elsif request.fullpath == "/users/posts" %>
           <li class="nav-item">
             <%= link_to new_users_post_path, class: "nav-link", method: :get do %>

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -8,6 +8,7 @@
     </div>
     <br>
     <%= form_with model: @profile, url: users_profile_path, local: true do |f| %>
+      <%= render 'layouts/error_messages', model: f.object %>
       <div class="text-center">
         <% image = @profile.present? && @profile.image.present? ? @profile.image : "user_default.png" %>
         <%= image_tag image , class: "rounded-circle", size: "120x120" %>

--- a/app/views/users/profiles/new.html.erb
+++ b/app/views/users/profiles/new.html.erb
@@ -10,6 +10,7 @@
     <br>
     <div style="padding-left:50px">
       <%= form_with model: @profile, url: { controller: "profiles", action: "create" }, local: true do |f| %>
+        <%= render 'layouts/error_messages', model: f.object %>
         <div class="form-group">
           <div class="form-inline">
             <i class="fas fa-user"></i>

--- a/db/migrate/20230807080430_change_column_null_to_profile.rb
+++ b/db/migrate/20230807080430_change_column_null_to_profile.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullToProfile < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :profiles, :registration_date, false
+    change_column_null :profiles, :hobby, false
+  end
+end


### PR DESCRIPTION
**PR概要**
プロフィール投稿時に項目が不足していた時に起こるヘッダーエラーの修正
プロフィール修正時にも同様のエラーが出たのでそれも修正
登録時のエラーメッセージの表示
不要なコメントアウトを削除。

**確認方法**
※マイグレーションファイルを作ったのでrails:db:migrateしてからお願いします。

1. プロフィールをまだ投稿していないユーザーでログイン
2. プロフィールの投稿ボタンを押下
3. 「登録日」「趣味」が必須項目なのでこれらを入力せずに登録ボタンを押す
4. 足りない項目のエラーメッセージが表示され、プロフィール登録ページに戻る。
5. プロフィールを修正するときも同様に確認してみてください。
<img width="1208" alt="スクリーンショット 2023-08-08 15 19 15" src="https://github.com/nishinotakay/teac-output-new/assets/100989880/6f8c74b3-2548-41a4-af90-1832bcd62268">




