### PR TITLE
Fix/edit_requests_article_spec

### DIFF
--- a/app/controllers/admins/articles_controller.rb
+++ b/app/controllers/admins/articles_controller.rb
@@ -15,11 +15,11 @@ module Admins
         finish:   params[:finish]
       }
       if (@paginate = filter.compact.blank?)
-        @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
+        @articles = Article.includes(:admin).all.order(created_at: params[:order]).page(params[:page]).per(30)
       else
         (@paginate = filter.compact.present?)
         filter[:order] = params[:order]
-        @articles = Article.sort_filter(filter).page(params[:page]).per(30)
+        @articles = Article.includes(:admin).all.sort_filter(filter).page(params[:page]).per(30)
       end
     end
 

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -34,7 +34,7 @@ module Users
     end
 
     def new
-      @article = current_user.articles.new # Article.new
+      @article = current_user.articles.new
     end
 
     def create

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -79,7 +79,7 @@ module Users
       else
         #flash[:danger] = "不正な操作です。"
         #redirect_to users_articles_path(page: params[:page])
-        render json: { error: "画像の挿入に失敗しました。" }, status: :unauthorized
+        render json: { error: '画像の挿入に失敗しました。' }, status: :unauthorized
       end
     end
 
@@ -98,7 +98,7 @@ module Users
     def check_article_owner
       @article = Article.find_by(id: params[:id])
       unless current_user.id == @article.user_id
-        flash[:danger] = "不正な操作です。"
+        flash[:danger] = '不正な操作です。'
         redirect_to users_articles_path(page: params[:page])
       end
     end

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -3,6 +3,7 @@
 module Users
   class ArticlesController < Users::Base
     protect_from_forgery
+    before_action :check_article_owner, only: %i[edit update destroy]
     before_action :set_article, except: %i[index show new create image]
     before_action :set_dashboard, only: %i[show new create edit update destroy]
 
@@ -18,11 +19,11 @@ module Users
       }
 
       if (@paginate = filter.compact.blank?)
-        @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
+        @articles = Article.includes(:admin, :user, :article_comments).order(created_at: params[:order]).page(params[:page]).per(30)
       else
         (@paginate = filter.compact.present?)
         filter[:order] = params[:order]
-        @articles = Article.sort_filter(filter).page(params[:page]).per(30)
+        @articles = Article.includes(:admin, :user, :article_comments).sort_filter(filter).page(params[:page]).per(30)
       end
     end
 
@@ -33,7 +34,7 @@ module Users
     end
 
     def new
-      @article = current_user.articles.new
+      @article = current_user.articles.new # Article.new
     end
 
     def create
@@ -72,9 +73,14 @@ module Users
     end
 
     def image
-      user = User.find(params[:user_id])
-      @article = user.articles.new(params.permit(:image))
-      render json: { name: @article.image.identifier, url: @article.image.url }
+      if current_user.id == params[:user_id].to_i
+        @article = current_user.articles.new(params.permit(:image))
+        render json: { name: @article.image.identifier, url: @article.image.url }
+      else
+        #flash[:danger] = "不正な操作です。"
+        #redirect_to users_articles_path(page: params[:page])
+        render json: { error: "画像の挿入に失敗しました。" }, status: :unauthorized
+      end
     end
 
     private
@@ -86,9 +92,17 @@ module Users
     # before_action
 
     def set_article
-      @article = current_user.articles.find(params[:id])
+      @article = current_user.articles.find_by(id: params[:id])
     end
 
+    def check_article_owner
+      @article = Article.find_by(id: params[:id])
+      unless current_user.id == @article.user_id
+        flash[:danger] = "不正な操作です。"
+        redirect_to users_articles_path(page: params[:page])
+      end
+    end
+    
     def set_dashboard
       params[:dashboard] ||= 'false'
       @dashboard = !(params[:dashboard] == 'false')

--- a/app/javascript/packs/users/articles_new_and_edit.js
+++ b/app/javascript/packs/users/articles_new_and_edit.js
@@ -69,6 +69,9 @@ $(function(){
     formData.append('image', image); // FormDataに画像を追加
     formData.append('user_id', e.target.dataset.userId); // FormDataに画像を追加
 
+    // CSRFトークンを取得
+    var token = $('meta[name="csrf-token"]').attr('content');
+
     // ajaxで画像をアップロード
     $.ajax({
       url: "/users/articles/image",
@@ -76,7 +79,10 @@ $(function(){
       data: formData,
       dataType: "json",
       contentType: false,
-      processData: false
+      processData: false,
+      headers: { 
+        'X-CSRF-Token': token  // こちらでトークンをヘッダーに追加
+      }
     })
     .done(function(data, textStatus, jqXHR){
       setImage(data['name'], data['url'])

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Articles', type: :request do
   let(:user_2) { build(:user, :b, confirmed_at: Date.today) }
   let(:article) { create(:article, user: user_1) }
 
-  describe 'GET /index' do
+  describe 'GET /index' do # 一覧画面の取得
     article_count = 2
     let(:articles_1) { create_list(:article, article_count, user: user_1) }
     let(:articles_2) { create_list(:article, article_count, user: user_2) }
@@ -56,7 +56,7 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'GET /show' do
+  describe 'GET /show' do # 詳細画面の取得
     context 'ログインユーザーが投稿者である場合' do
       it '記事詳細画面へ遷移する' do
         sign_in user_1
@@ -93,7 +93,7 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'GET /new' do
+  describe 'GET /new' do # 新規作成画面の取得
     context 'ログインしている場合' do
       it '記事投稿画面へ遷移する' do
         sign_in user_1
@@ -112,7 +112,7 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'GET /edit' do
+  describe 'GET /edit' do # 編集画面の取得
     context 'ログインユーザーが投稿者である場合' do
       it '記事編集画面へ遷移する' do
         sign_in user_1
@@ -146,7 +146,7 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'POST /create' do
+  describe 'POST /create' do # 新規作成の実行
     let(:params) { { article: attributes_for(:article, user_id: user_1.id) } }
 
     before(:each) { sign_in user_1 }
@@ -180,7 +180,7 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'PATCH /update' do
+  describe 'PATCH /update' do # 記事の更新
     let(:article) { create(:article, user: user_1) }
 
     before(:each) do
@@ -234,7 +234,7 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'DELETE /destroy' do
+  describe 'DELETE /destroy' do # 記事の削除
     let(:article) { create(:article, user: user_1) }
 
     before(:each) do
@@ -279,8 +279,8 @@ RSpec.describe 'Articles', type: :request do
     end
   end
 
-  describe 'POST /image' do
-    context 'ログインユーザーが投稿者である場合' do # 記事の生成前、データベース保存前の画像ドロップアンドドロップ作業
+  describe 'POST /image' do # 画像のアップロード
+    context 'ログインユーザーが投稿者である場合' do
       it '記事に画像を添付できる' do
         user_1.save
         image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,26 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe 'Articles', type: :request do
-  let(:user_1) { build(:user, :a, confirmed_at: Date.today) }
-  let(:user_2) { build(:user, :b, confirmed_at: Date.today) }
-  let(:article) { create(:article, user: user_1) }
+  let(:user_a) { build(:user, :a, confirmed_at: Date.today) }
+  let(:user_b) { build(:user, :b, confirmed_at: Date.today) }
+  let(:article) { create(:article, user: user_a) }
 
   describe 'GET /index' do # 一覧画面の取得
     article_count = 2
-    let(:articles_1) { create_list(:article, article_count, user: user_1) }
-    let(:articles_2) { create_list(:article, article_count, user: user_2) }
+    let(:articles_a) { create_list(:article, article_count, user: user_a) }
+    let(:articles_b) { create_list(:article, article_count, user: user_b) }
 
-    before(:each) { articles_1 }
+    before(:each) { articles_a }
 
     context 'ログインユーザーが投稿者である場合' do
       it '記事一覧画面へ遷移する' do
-        articles_2
-        sign_in user_1
+        articles_b
+        sign_in user_a
         get users_articles_url # 記事一覧画面へ遷移
         expect(response.status).to eq 200
-        expect(response.body).to include user_1.name
-        expect(response.body).to include user_2.name
-        articles_1.concat(articles_2).each do |a|
+        expect(response.body).to include user_a.name
+        expect(response.body).to include user_b.name
+        articles_a.concat(articles_2).each do |a|
           expect(response.body).to include a.title
           expect(response.body).to include a.sub_title
           expect(response.body).to include '編集'
@@ -31,12 +31,12 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインユーザーが投稿者でない場合' do
       it '記事一覧画面へ遷移する' do
-        sign_in user_2 # ユーザー２でログイン
+        sign_in user_b # ユーザー２でログイン
         get users_articles_url
         expect(response.status).to eq 200
-        expect(response.body).to include user_1.name
-        expect(response.body).to include user_2.name
-        articles_1.each do |a|
+        expect(response.body).to include user_a.name
+        expect(response.body).to include user_b.name
+        articles_a.each do |a|
           expect(response.body).to include a.title
           expect(response.body).to include a.sub_title
           expect(response.body).not_to include '編集'
@@ -47,7 +47,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインしていない場合' do
       it '記事一覧画面へ遷移せず、ログインページにリダイレクトする' do
-        sign_out user_2
+        sign_out user_b
         get users_articles_url
         expect(response.status).to eq 302
         expect(response).to redirect_to user_session_url
@@ -59,7 +59,7 @@ RSpec.describe 'Articles', type: :request do
   describe 'GET /show' do # 詳細画面の取得
     context 'ログインユーザーが投稿者である場合' do
       it '記事詳細画面へ遷移する' do
-        sign_in user_1
+        sign_in user_a
         get users_article_url(article) # ユーザー１投稿の記事詳細画面へ
         expect(response.status).to eq 200
         expect(response.body).to include '編集'
@@ -72,7 +72,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインユーザーが投稿者ではない場合' do
       it '記事詳細画面へ遷移し、編集・削除ボタンが表示されない' do
-        sign_in user_2
+        sign_in user_b
         get users_article_url(article) # ユーザー１が投稿した記事詳細画面へ
         expect(response.status).to eq 200
         expect(response.body).not_to include '編集'
@@ -96,7 +96,7 @@ RSpec.describe 'Articles', type: :request do
   describe 'GET /new' do # 新規作成画面の取得
     context 'ログインしている場合' do
       it '記事投稿画面へ遷移する' do
-        sign_in user_1
+        sign_in user_a
         get new_users_article_url
         expect(response.status).to eq 200
       end
@@ -115,7 +115,7 @@ RSpec.describe 'Articles', type: :request do
   describe 'GET /edit' do # 編集画面の取得
     context 'ログインユーザーが投稿者である場合' do
       it '記事編集画面へ遷移する' do
-        sign_in user_1
+        sign_in user_a
         get edit_users_article_url(article)
         expect(response.status).to eq 200
         expect(response.body).to include '<input', 'title-form', article.title, '/>'
@@ -128,7 +128,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインユーザーが投稿者でない場合' do
       it '記事編集画面へ遷移せず、記事一覧画面へリダイレクトする' do
-        sign_in user_2
+        sign_in user_b
         get edit_users_article_url(article)
         expect(response.status).to eq 302
         expect(response).to redirect_to users_articles_url
@@ -147,9 +147,9 @@ RSpec.describe 'Articles', type: :request do
   end
 
   describe 'POST /create' do # 新規作成の実行
-    let(:params) { { article: attributes_for(:article, user_id: user_1.id) } }
+    let(:params) { { article: attributes_for(:article, user_id: user_a.id) } }
 
-    before(:each) { sign_in user_1 }
+    before(:each) { sign_in user_a }
 
     context '記事投稿が成功した場合' do
       it '記事が保存され、記事詳細画面へ遷移する' do
@@ -171,7 +171,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'SQL文を入力した場合' do
       it '記事投稿が成功し、クエリが実行されないこと' do
-        post users_articles_url, params: { article: { title: 'a', sub_title: 'b', content: 'c', user_id: user_1.id } } # 一件目の記事を生成
+        post users_articles_url, params: { article: { title: 'a', sub_title: 'b', content: 'c', user_id: user_a.id } } # 一件目の記事を生成
         params[:article][:content] = 'DELETE FROM articles;' # ２件目の記事生成用、本文に全ての記事を削除するクエリを指定
         expect { post users_articles_url params: params }.to change(Article, :count).by(1) # クエリを入力しても記事投稿が成功する
         expect(Article.first.title).to eq 'a' # クエリが発行されず、１件目の記事が存在する
@@ -189,7 +189,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインしていない場合' do
       it '記事は作成されず、トップページへリダイレクトする' do
-        sign_out user_1
+        sign_out user_a
         post users_articles_url params: params
         expect(response.status).to eq 302
         expect(response).to redirect_to user_session_url
@@ -199,10 +199,10 @@ RSpec.describe 'Articles', type: :request do
   end
 
   describe 'PATCH /update' do # 記事の更新
-    let(:article) { create(:article, user: user_1) }
+    let(:article) { create(:article, user: user_a) }
 
     before(:each) do
-      sign_in user_1
+      sign_in user_a
       article
     end
 
@@ -230,9 +230,9 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインユーザーが投稿者ではない場合' do
       it '記事は更新されず、記事一覧画面へリダイレクトする' do
-        sign_in user_2
+        sign_in user_b
         params = { article: { title: 'a', sub_title: 'b', content: 'c' } }
-        patch users_article_url(article, params: params) # user_1の投稿記事を編集する
+        patch users_article_url(article, params: params) # user_a の投稿記事を編集する
         article.reload
         expect(response.status).to eq 302
         expect(response).to redirect_to users_articles_url
@@ -242,7 +242,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインしていない場合' do
       it '記事は更新されず、トップページへリダイレクトする' do
-        sign_out user_1
+        sign_out user_a
         params = { article: { title: 'a', sub_title: 'b', content: 'c' } }
         patch users_article_url(article, params: params)
         expect(response.status).to eq 302
@@ -253,10 +253,10 @@ RSpec.describe 'Articles', type: :request do
   end
 
   describe 'DELETE /destroy' do # 記事の削除
-    let(:article) { create(:article, user: user_1) }
+    let(:article) { create(:article, user: user_a) }
 
     before(:each) do
-      sign_in user_1
+      sign_in user_a
       article
     end
 
@@ -265,7 +265,7 @@ RSpec.describe 'Articles', type: :request do
         expect { delete users_article_url(article, dashboard: true) }.to change(Article, :count).by(-1)
         expect(response.status).to eq 302
         expect(flash[:notice]).to eq '記事を削除しました。'
-        expect(response).to redirect_to users_dash_boards_url(user_1)
+        expect(response).to redirect_to users_dash_boards_url(user_a)
       end
 
       it '記事の削除ができ、記事一覧画面へ遷移する' do # dashboard: false
@@ -278,7 +278,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインユーザーが投稿者ではない場合' do
       it '削除されず、記事一覧画面へリダイレクトする' do
-        sign_in user_2
+        sign_in user_b
         expect { delete users_article_url(article) }.not_to change(Article, :count) # 記事の数は変化しない
         expect(response.status).to eq 302
         expect(response).to redirect_to users_articles_url
@@ -288,7 +288,7 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインしていない場合' do
       it '記事は削除されず、トップページへリダイレクトする' do
-        sign_out user_1
+        sign_out user_a
         expect { delete users_article_url(article) }.not_to change(Article, :count)
         expect(response.status).to eq 302
         expect(response).to redirect_to user_session_url
@@ -300,15 +300,15 @@ RSpec.describe 'Articles', type: :request do
   describe 'POST /image' do # 画像のアップロード
     context 'ログインユーザーが投稿者である場合' do
       it '記事に画像を添付できる' do
-        user_1.save
+        user_a.save
         image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')
-        sign_in user_1
-        post users_articles_image_url, params: { image: image, user_id: user_1.id }
+        sign_in user_a
+        post users_articles_image_url, params: { image: image, user_id: user_a.id }
         expect(JSON.parse(response.body)['name']).to eq 'ruby.png'
         expect(JSON.parse(response.body)['url']).to include 'ruby.png'
         expect(JSON.parse(response.body)['url']).to include '/uploads/tmp/'
         uploaded_image_url = JSON.parse(response.body)['url']
-        article_params = { title: 'a', sub_title: 'a', content: "<img src=\"#{uploaded_image_url}\">", user: user_1.id } # ここから画像投稿までのテストをする
+        article_params = { title: 'a', sub_title: 'a', content: "<img src=\"#{uploaded_image_url}\">", user: user_a.id } # ここから画像投稿までのテストをする
         post users_articles_url, params: { article: article_params }
         expect(response.status).to eq 302
         expect(flash[:notice]).to eq '記事を作成しました。'
@@ -318,10 +318,10 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインユーザーが投稿者ではない場合' do # 悪意あるユーザーが、他ユーザーの投稿で画像添付できないテスト
       it '記事に画像を添付できない' do
-        user_1.save
+        user_a.save
         image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')
-        sign_in user_2
-        post users_articles_image_url, params: { image: image, user_id: user_1.id }
+        sign_in user_b
+        post users_articles_image_url, params: { image: image, user_id: user_a.id }
         expect(response.status).to eq 401 # 401はUnauthorizedのステータスコードです
         json_response = JSON.parse(response.body)
         expect(json_response['error']).to eq '画像の挿入に失敗しました。'
@@ -330,9 +330,9 @@ RSpec.describe 'Articles', type: :request do
 
     context 'ログインしていない場合' do
       it '記事の画像は保存されず、トップページへリダイレクトする' do
-        sign_out user_1
+        sign_out user_a
         image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')
-        post users_articles_image_url, params: { image: image, user_id: user_1.id }
+        post users_articles_image_url, params: { image: image, user_id: user_a.id }
         expect(response.status).to eq 302
         expect(response).to redirect_to user_session_url
         expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Articles', type: :request do
     let(:articles_1) { create_list(:article, article_count, user: user_1) }
     let(:articles_2) { create_list(:article, article_count, user: user_2) }
 
-    before { articles_1 }
+    before(:each) { articles_1 }
 
     context 'ログインユーザーが投稿者である場合' do
       it '記事一覧画面へ遷移する' do
@@ -39,8 +39,8 @@ RSpec.describe 'Articles', type: :request do
         articles_1.each do |a|
           expect(response.body).to include a.title
           expect(response.body).to include a.sub_title
-          expect(response.body).to_not include '編集'
-          expect(response.body).to_not include '削除'
+          expect(response.body).not_to include '編集'
+          expect(response.body).not_to include '削除'
         end
       end
     end
@@ -75,8 +75,8 @@ RSpec.describe 'Articles', type: :request do
         sign_in user_2
         get users_article_url(article) # ユーザー１が投稿した記事詳細画面へ
         expect(response.status).to eq 200
-        expect(response.body).to_not include '編集'
-        expect(response.body).to_not include '削除'
+        expect(response.body).not_to include '編集'
+        expect(response.body).not_to include '削除'
         expect(response.body).to include article.title
         expect(response.body).to include article.sub_title
         expect(response.body).to include article.content
@@ -149,12 +149,11 @@ RSpec.describe 'Articles', type: :request do
   describe 'POST /create' do
     let(:params) { { article: attributes_for(:article, user_id: user_1.id) } }
 
-    before { sign_in user_1 }
+    before(:each) { sign_in user_1 }
 
     context '記事投稿が成功した場合' do
       it '記事が保存され、記事詳細画面へ遷移する' do
-        #binding.pry
-        expect{ post users_articles_url params: params }.to change(Article, :count).by(1)
+        expect { post users_articles_url params: params }.to change(Article, :count).by(1)
         expect(response.status).to eq 302
         expect(flash[:notice]).to eq '記事を作成しました。'
         expect(response).to redirect_to users_article_url(Article.last, dashboard: false)
@@ -164,7 +163,7 @@ RSpec.describe 'Articles', type: :request do
     context '記事投稿が失敗した場合' do
       it '記事は作成されず、記事投稿画面へ遷移する' do
         params[:article][:title] = nil
-        expect{ post users_articles_url params: params }.to change(Article, :count).by(0)
+        expect { post users_articles_url params: params }.to change(Article, :count).by(0)
         expect(response.status).to eq 200
         expect(flash[:alert]).to eq '記事の作成に失敗しました。'
       end
@@ -184,7 +183,7 @@ RSpec.describe 'Articles', type: :request do
   describe 'PATCH /update' do
     let(:article) { create(:article, user: user_1) }
 
-    before do
+    before(:each) do
       sign_in user_1
       article
     end
@@ -238,21 +237,21 @@ RSpec.describe 'Articles', type: :request do
   describe 'DELETE /destroy' do
     let(:article) { create(:article, user: user_1) }
 
-    before do
+    before(:each) do
       sign_in user_1
       article
     end
 
     context 'ログインユーザーが投稿者である場合' do
       it '記事の削除ができ、投稿した記事一覧画面へ遷移する' do # dashboard: true
-        expect{ delete users_article_url(article, dashboard: true) }.to change(Article, :count).by(-1)
+        expect { delete users_article_url(article, dashboard: true) }.to change(Article, :count).by(-1)
         expect(response.status).to eq 302
         expect(flash[:notice]).to eq '記事を削除しました。'
         expect(response).to redirect_to users_dash_boards_url(user_1)
       end
 
       it '記事の削除ができ、記事一覧画面へ遷移する' do # dashboard: false
-        expect{ delete users_article_url(article, dashboard: false) }.to change(Article, :count).by(-1)
+        expect { delete users_article_url(article, dashboard: false) }.to change(Article, :count).by(-1)
         expect(response.status).to eq 302
         expect(flash[:notice]).to eq '記事を削除しました。'
         expect(response).to redirect_to users_articles_url
@@ -262,7 +261,7 @@ RSpec.describe 'Articles', type: :request do
     context 'ログインユーザーが投稿者ではない場合' do
       it '削除されず、記事一覧画面へリダイレクトする' do
         sign_in user_2
-        expect{ delete users_article_url(article) }.not_to change(Article, :count) # 記事の数は変化しない
+        expect { delete users_article_url(article) }.not_to change(Article, :count) # 記事の数は変化しない
         expect(response.status).to eq 302
         expect(response).to redirect_to users_articles_url
         expect(flash[:danger]).to eq '不正な操作です。'
@@ -272,7 +271,7 @@ RSpec.describe 'Articles', type: :request do
     context 'ログインしていない場合' do
       it '記事は削除されず、トップページへリダイレクトする' do
         sign_out user_1
-        expect{ delete users_article_url(article) }.not_to change(Article, :count)
+        expect { delete users_article_url(article) }.not_to change(Article, :count)
         expect(response.status).to eq 302
         expect(response).to redirect_to user_session_url
         expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
@@ -284,15 +283,14 @@ RSpec.describe 'Articles', type: :request do
     context 'ログインユーザーが投稿者である場合' do # 記事の生成前、データベース保存前の画像ドロップアンドドロップ作業
       it '記事に画像を添付できる' do
         user_1.save
-        image = fixture_file_upload("spec/fixtures/files/ruby.png", 'image/png')
+        image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')
         sign_in user_1
-        #binding.pry
-        post users_articles_image_url, params: {image: image, user_id: user_1.id}
-        expect(JSON.parse(response.body)['name']).to eq "ruby.png"
-        expect(JSON.parse(response.body)['url']).to include "ruby.png"
-        expect(JSON.parse(response.body)['url']).to include "/uploads/tmp/"
+        post users_articles_image_url, params: { image: image, user_id: user_1.id }
+        expect(JSON.parse(response.body)['name']).to eq 'ruby.png'
+        expect(JSON.parse(response.body)['url']).to include 'ruby.png'
+        expect(JSON.parse(response.body)['url']).to include '/uploads/tmp/'
         uploaded_image_url = JSON.parse(response.body)['url']
-        article_params = { title:'a', sub_title:'a', content: "<img src=\"#{uploaded_image_url}\">", user: user_1.id } # ここから画像投稿までのテストをする
+        article_params = { title: 'a', sub_title: 'a', content: "<img src=\"#{uploaded_image_url}\">", user: user_1.id } # ここから画像投稿までのテストをする
         post users_articles_url, params: { article: article_params }
         expect(response.status).to eq 302
         expect(flash[:notice]).to eq '記事を作成しました。'
@@ -303,9 +301,9 @@ RSpec.describe 'Articles', type: :request do
     context 'ログインユーザーが投稿者ではない場合' do # 悪意あるユーザーが、他ユーザーの投稿で画像添付できないテスト
       it '記事に画像を添付できない' do
         user_1.save
-        image = fixture_file_upload("spec/fixtures/files/ruby.png", 'image/png')
+        image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')
         sign_in user_2
-        post users_articles_image_url, params: {image: image, user_id: user_1.id}
+        post users_articles_image_url, params: { image: image, user_id: user_1.id }
         expect(response.status).to eq 401 # 401はUnauthorizedのステータスコードです
         json_response = JSON.parse(response.body)
         expect(json_response['error']).to eq '画像の挿入に失敗しました。'
@@ -315,8 +313,8 @@ RSpec.describe 'Articles', type: :request do
     context 'ログインしていない場合' do
       it '記事の画像は保存されず、トップページへリダイレクトする' do
         sign_out user_1
-        image = fixture_file_upload("spec/fixtures/files/ruby.png", 'image/png')
-        post users_articles_image_url, params: {image: image, user_id: user_1.id}
+        image = fixture_file_upload('spec/fixtures/files/ruby.png', 'image/png')
+        post users_articles_image_url, params: { image: image, user_id: user_1.id }
         expect(response.status).to eq 302
         expect(response).to redirect_to user_session_url
         expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
@@ -324,5 +322,4 @@ RSpec.describe 'Articles', type: :request do
       end
     end
   end
-
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -12,41 +12,55 @@ RSpec.describe 'Articles', type: :request do
 
     before { articles_1 }
 
-    context 'user is writer' do
-      it 'success' do
+    context 'ログインユーザーが投稿者である場合' do
+      it '記事一覧画面へ遷移する' do
         articles_2
         sign_in user_1
-        get users_articles_url
+        get users_articles_url # 記事一覧画面へ遷移
         expect(response.status).to eq 200
-        expect(response.body).to include '<td>' + user_1.name + '</td>'
-        expect(response.body).to include '<td>' + user_2.name + '</td>'
+        expect(response.body).to include user_1.name
+        expect(response.body).to include user_2.name
         articles_1.concat(articles_2).each do |a|
           expect(response.body).to include a.title
           expect(response.body).to include a.sub_title
+          expect(response.body).to include '編集'
+          expect(response.body).to include '削除'
         end
       end
     end
 
-    context 'user isnot writer' do
-      it 'success' do
-        sign_in user_2
+    context 'ログインユーザーが投稿者でない場合' do
+      it '記事一覧画面へ遷移する' do
+        sign_in user_2 # ユーザー２でログイン
         get users_articles_url
         expect(response.status).to eq 200
-        expect(response.body).to include '<td>' + user_1.name + '</td>'
-        expect(response.body).to_not include '<td>' + user_2.name + '</td>'
+        expect(response.body).to include user_1.name
+        expect(response.body).to include user_2.name
         articles_1.each do |a|
           expect(response.body).to include a.title
           expect(response.body).to include a.sub_title
+          expect(response.body).to_not include '編集'
+          expect(response.body).to_not include '削除'
         end
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事一覧画面へ遷移せず、ログインページにリダイレクトする' do
+        sign_out user_2
+        get users_articles_url
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
       end
     end
   end
 
   describe 'GET /show' do
-    context 'user eq writer' do
-      it 'success' do
+    context 'ログインユーザーが投稿者である場合' do
+      it '記事詳細画面へ遷移する' do
         sign_in user_1
-        get users_article_url(article)
+        get users_article_url(article) # ユーザー１投稿の記事詳細画面へ
         expect(response.status).to eq 200
         expect(response.body).to include '編集'
         expect(response.body).to include '削除'
@@ -56,10 +70,10 @@ RSpec.describe 'Articles', type: :request do
       end
     end
 
-    context 'user not_eq writer' do
-      it 'success' do
+    context 'ログインユーザーが投稿者ではない場合' do
+      it '記事詳細画面へ遷移し、編集・削除ボタンが表示されない' do
         sign_in user_2
-        get users_article_url(article)
+        get users_article_url(article) # ユーザー１が投稿した記事詳細画面へ
         expect(response.status).to eq 200
         expect(response.body).to_not include '編集'
         expect(response.body).to_not include '削除'
@@ -68,28 +82,67 @@ RSpec.describe 'Articles', type: :request do
         expect(response.body).to include article.content
       end
     end
+
+    context 'ログインしていない場合' do
+      it '記事詳細画面へ遷移せず、ログインページにリダイレクトする' do
+        get users_article_url(article)
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+      end
+    end
   end
 
   describe 'GET /new' do
-    it 'success' do
-      sign_in user_1
-      get new_users_article_url
-      expect(response.status).to eq 200
+    context 'ログインしている場合' do
+      it '記事投稿画面へ遷移する' do
+        sign_in user_1
+        get new_users_article_url
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事投稿画面へ遷移せず、ログインページにリダイレクトする' do
+        get new_users_article_url
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+      end
     end
   end
 
   describe 'GET /edit' do
-    it 'success' do
-      sign_in user_1
-      get edit_users_article_url(article)
-      expect(response.status).to eq 200
-      expect(response.body).to include '<input', 'title-form', article.title, '/>'
-      expect(response.body).to include '<input', 'subtitle-form', article.sub_title, '/>'
-      expect(response.body).to include '<textarea', 'markdown-editor', '>' + article.content, '</textarea>'
-      expect(response.body).to include '<span class="preview-title">' + article.title + '</span>'
-      expect(response.body).to include '<span class="preview-subtitle">' + article.sub_title + '</span>'
-      expect(response.body).to include 'markdown-editor', article.content, '</div>'
-      expect(response.body).to include 'preview-content', article.content, '</div>'
+    context 'ログインユーザーが投稿者である場合' do
+      it '記事編集画面へ遷移する' do
+        sign_in user_1
+        get edit_users_article_url(article)
+        expect(response.status).to eq 200
+        expect(response.body).to include '<input', 'title-form', article.title, '/>'
+        expect(response.body).to include '<input', 'subtitle-form', article.sub_title, '/>'
+        expect(response.body).to include '<textarea', 'markdown-editor', '>', article.content, '</textarea>'
+        expect(response.body).to include 'markdown-editor', article.content, '</div>'
+        expect(response.body).to include 'preview-side', article.content, '</div>'
+      end
+    end
+
+    context 'ログインユーザーが投稿者でない場合' do
+      it '記事編集画面へ遷移せず、記事一覧画面へリダイレクトする' do
+        sign_in user_2
+        get edit_users_article_url(article)
+        expect(response.status).to eq 302
+        expect(response).to redirect_to users_articles_url
+        expect(flash[:danger]).to eq '不正な操作です。'
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事編集画面へ遷移せず、ログインページにリダイレクトする' do
+        get edit_users_article_url(article)
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+      end
     end
   end
 
@@ -98,21 +151,33 @@ RSpec.describe 'Articles', type: :request do
 
     before { sign_in user_1 }
 
-    it 'success' do
-      expect{
-        post users_articles_url params: params
-      }.to change(Article, :count).by(1)
-      expect(response.status).to eq 302
-      expect(flash[:notice]).to eq '記事を作成しました。'
-      expect(response).to redirect_to users_article_url(Article.count)
+    context '記事投稿が成功した場合' do
+      it '記事が保存され、記事詳細画面へ遷移する' do
+        #binding.pry
+        expect{ post users_articles_url params: params }.to change(Article, :count).by(1)
+        expect(response.status).to eq 302
+        expect(flash[:notice]).to eq '記事を作成しました。'
+        expect(response).to redirect_to users_article_url(Article.last, dashboard: false)
+      end
     end
 
-    it 'failure' do
-      params[:article][:title] = nil
-      expect{
+    context '記事投稿が失敗した場合' do
+      it '記事は作成されず、記事投稿画面へ遷移する' do
+        params[:article][:title] = nil
+        expect{ post users_articles_url params: params }.to change(Article, :count).by(0)
+        expect(response.status).to eq 200
+        expect(flash[:alert]).to eq '記事の作成に失敗しました。'
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事は作成されず、トップページへリダイレクトする' do
+        sign_out user_1
         post users_articles_url params: params
-      }.to change(Article, :count).by(0)
-      expect(flash[:alert]).to eq '記事の作成に失敗しました。'
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+      end
     end
   end
 
@@ -124,20 +189,49 @@ RSpec.describe 'Articles', type: :request do
       article
     end
 
-    it 'success' do
-      params = { article: { sub_title: 'b', content: 'c' } }
-      patch users_article_url(article, params: params)
-      article.reload
-      expect(response.status).to eq 302
-      expect(flash[:notice]).to eq '記事を編集しました。'
-      expect(response).to redirect_to users_article_url(article.id)
+    context 'ログインユーザーが投稿者であり' do
+      context '編集内容が適切な場合' do
+        it '記事を編集できる' do
+          params = { article: { title: 'a', sub_title: 'b', content: 'c' } }
+          patch users_article_url(article, params: params)
+          article.reload
+          expect(response.status).to eq 302
+          expect(flash[:notice]).to eq '記事を編集しました。'
+          expect(response).to redirect_to users_article_url(Article.last, dashboard: false)
+        end
+      end
+
+      context '編集内容が不適切な場合' do
+        it '記事を編集できない' do
+          params = { article: { title: nil, sub_title: 'b', content: 'c' } }
+          patch users_article_url(article, params: params)
+          article.reload
+          expect(flash[:alert]).to eq '記事の編集に失敗しました。'
+        end
+      end
     end
 
-    it 'failure' do
-      params = { article: { title: nil, sub_title: 'b', content: 'c' } }
-      patch users_article_url(article, params: params)
-      article.reload
-      expect(flash[:alert]).to eq '記事の編集に失敗しました。'
+    context 'ログインユーザーが投稿者ではない場合' do
+      it '記事は更新されず、記事一覧画面へリダイレクトする' do
+        sign_in user_2
+        params = { article: { title: 'a', sub_title: 'b', content: 'c' } }
+        patch users_article_url(article, params: params) # user_1の投稿記事を編集する
+        article.reload
+        expect(response.status).to eq 302
+        expect(response).to redirect_to users_articles_url
+        expect(flash[:danger]).to eq '不正な操作です。'
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事は更新されず、トップページへリダイレクトする' do
+        sign_out user_1
+        params = { article: { title: 'a', sub_title: 'b', content: 'c' } }
+        patch users_article_url(article, params: params)
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+      end
     end
   end
 
@@ -149,34 +243,86 @@ RSpec.describe 'Articles', type: :request do
       article
     end
 
-    it 'success(dash_board)' do
-      expect{
-        delete users_article_url(article, dashboard: true)
-      }.to change(Article, :count).by(-1)
-      expect(response.status).to eq 302
-      expect(flash[:notice]).to eq '記事を削除しました。'
-      expect(response).to redirect_to users_dash_boards_url(user_1)
+    context 'ログインユーザーが投稿者である場合' do
+      it '記事の削除ができ、投稿した記事一覧画面へ遷移する' do # dashboard: true
+        expect{ delete users_article_url(article, dashboard: true) }.to change(Article, :count).by(-1)
+        expect(response.status).to eq 302
+        expect(flash[:notice]).to eq '記事を削除しました。'
+        expect(response).to redirect_to users_dash_boards_url(user_1)
+      end
+
+      it '記事の削除ができ、記事一覧画面へ遷移する' do # dashboard: false
+        expect{ delete users_article_url(article, dashboard: false) }.to change(Article, :count).by(-1)
+        expect(response.status).to eq 302
+        expect(flash[:notice]).to eq '記事を削除しました。'
+        expect(response).to redirect_to users_articles_url
+      end
     end
 
-    it 'success(articles/index)' do
-      expect{
-        delete users_article_url(article, dashboard: false)
-      }.to change(Article, :count).by(-1)
-      expect(response.status).to eq 302
-      expect(flash[:notice]).to eq '記事を削除しました。'
-      expect(response).to redirect_to users_articles_url
+    context 'ログインユーザーが投稿者ではない場合' do
+      it '削除されず、記事一覧画面へリダイレクトする' do
+        sign_in user_2
+        expect{ delete users_article_url(article) }.not_to change(Article, :count) # 記事の数は変化しない
+        expect(response.status).to eq 302
+        expect(response).to redirect_to users_articles_url
+        expect(flash[:danger]).to eq '不正な操作です。'
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事は削除されず、トップページへリダイレクトする' do
+        sign_out user_1
+        expect{ delete users_article_url(article) }.not_to change(Article, :count)
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+      end
     end
   end
 
   describe 'POST /image' do
-    it 'success' do
-      user_1.save
-      image = fixture_file_upload("spec/fixtures/ruby.png", 'image/png')
-      sign_in user_1
-      post users_articles_image_url, params: {image: image, user_id: user_1.id}
-      expect(JSON.parse(response.body)['name']).to eq "ruby.png"
-      expect(JSON.parse(response.body)['url']).to include "ruby.png"
-      expect(JSON.parse(response.body)['url']).to include "/uploads/tmp/"
+    context 'ログインユーザーが投稿者である場合' do # 記事の生成前、データベース保存前の画像ドロップアンドドロップ作業
+      it '記事に画像を添付できる' do
+        user_1.save
+        image = fixture_file_upload("spec/fixtures/files/ruby.png", 'image/png')
+        sign_in user_1
+        #binding.pry
+        post users_articles_image_url, params: {image: image, user_id: user_1.id}
+        expect(JSON.parse(response.body)['name']).to eq "ruby.png"
+        expect(JSON.parse(response.body)['url']).to include "ruby.png"
+        expect(JSON.parse(response.body)['url']).to include "/uploads/tmp/"
+        uploaded_image_url = JSON.parse(response.body)['url']
+        article_params = { title:'a', sub_title:'a', content: "<img src=\"#{uploaded_image_url}\">", user: user_1.id } # ここから画像投稿までのテストをする
+        post users_articles_url, params: { article: article_params }
+        expect(response.status).to eq 302
+        expect(flash[:notice]).to eq '記事を作成しました。'
+        expect(response).to redirect_to users_article_url(Article.last, dashboard: false)
+      end
+    end
+
+    context 'ログインユーザーが投稿者ではない場合' do # 悪意あるユーザーが、他ユーザーの投稿で画像添付できないテスト
+      it '記事に画像を添付できない' do
+        user_1.save
+        image = fixture_file_upload("spec/fixtures/files/ruby.png", 'image/png')
+        sign_in user_2
+        post users_articles_image_url, params: {image: image, user_id: user_1.id}
+        expect(response.status).to eq 401 # 401はUnauthorizedのステータスコードです
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']).to eq '画像の挿入に失敗しました。'
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '記事の画像は保存されず、トップページへリダイレクトする' do
+        sign_out user_1
+        image = fixture_file_upload("spec/fixtures/files/ruby.png", 'image/png')
+        post users_articles_image_url, params: {image: image, user_id: user_1.id}
+        expect(response.status).to eq 302
+        expect(response).to redirect_to user_session_url
+        expect(flash[:alert]).to eq 'ログインもしくはアカウント登録してください。'
+        expect(Article.last).to be_blank
+      end
     end
   end
+
 end


### PR DESCRIPTION
**PR概要**
spec/requests/articles_spec.rb を編集致しました。
レビューとご確認お願いします。

**実装内容**
既存テストのエラー解消
以下のテスト項目を追加
・各テストでログインしていない場合
・SQL文を入力した場合　POST /create
・正規表現を入力した場合　POST /create

修正箇所
・usersとadmin の articles_controller.rb indexアクションのN＋1問題部分を修正。

**確認手順**
bin/docker/bundle/exec rspec spec/requests/articles_spec.rb

**QAテストシート**
https://docs.google.com/spreadsheets/d/16BqCFNKKG0tpCQMsiXOKIhEDXpK4KOTJ0UDsiEIvhdE/edit#gid=1675292528

**確認したいこと**
・POST /create でのみ、SQL文、正規表現のテスト実装しております。PATCH /update でも必要でしょうか？
・describe 部分を英語表記にしております。日本語が読みやすい場合はコメントアウトの表記に変更致します。
・merge 前に、コメントアウトを削除致します。

**お願いしたいこと**
・テスト実行後に1件、BulletでN＋1問題検出のエラー発生しておりますが、前回MTGで、該当箇所は実装担当の方へ依頼して、そのままPRするよう西野さんに確認しております。ご対応願います🙇‍♂️　includeでまとめればテスト成功します。

**実装画面スクリーンショット**
<img width="1440" alt="スクリーンショット 2023-09-07 19 42 11" src="https://github.com/nishinotakay/teac-output-new/assets/68493893/53425d8b-6212-40b9-87be-32a435a64a14">
