### PR TITLE
Feat/tweet text search

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -9,9 +9,20 @@ module Users
     before_action :correct_tweet_user, only: %i[edit update destroy]
 
     def index
-      @users = User.all
-      @tweets = Tweet.all.order(created_at: :desc).page(params[:page]).per(30)
-      # @articles = Article.order(created_at: params[:order]).page(params[:page]).per(30)
+      params[:order] ||= 'DESC'
+      filter = {
+        author: params[:author],
+        post: params[:post],
+        start: params[:start],
+        finish: params[:finish]
+      }
+
+      if filter.compact.blank?
+        @tweets = Tweet.order(created_at: params[:order]).page(params[:page]).per(30)
+      else
+        filter[:order] = params[:order]
+        @tweets = Tweet.sort_filter(filter).page(params[:page]).per(30)
+      end
     end
 
     def show

--- a/app/javascript/packs/users/index_articles_and_dashboards.js
+++ b/app/javascript/packs/users/index_articles_and_dashboards.js
@@ -53,7 +53,7 @@ $(function(){
   $('.submit-btn').on('click', function(){
     var sort = $('#sort-select option:selected').val()
     var search = "order=" + sort
-    var values = ['author', 'title', 'subtitle', 'content', 'start', 'finish' ,'body']
+    var values = ['author', 'title', 'subtitle', 'content', 'start', 'finish' ,'body', 'post']
     $.each(values, function(index, value){
       var input = $('#input-' + value).val()
       if(input){

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -6,6 +6,18 @@ class Tweet < ApplicationRecord
   validates :post, presence: true, length: { maximum: 255 }
   validate :image_count_validation, :image_size_varidation, :image_type_validation
 
+  def self.sort_filter(filter)
+    start = Time.zone.parse(filter[:start].presence || '2022-01-01').beginning_of_day
+    finish = Time.zone.parse(filter[:finish].presence || Date.current.to_s).end_of_day
+
+    left_joins(:user)
+      .where('tweets.post LIKE :post', post: "%#{filter[:post]}%")
+      .where('tweets.created_at BETWEEN ? AND ?', start, finish)
+      .where('users.name LIKE :author', author: "%#{filter[:author]}%")
+      .order("tweets.created_at #{filter[:order]}")
+      .presence || Tweet.none
+  end
+
   private
 
   def image_count_validation

--- a/app/views/users/tweets/index.html.erb
+++ b/app/views/users/tweets/index.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag "users/tweets" %>
+<%= javascript_pack_tag "users/tweets","users/index_articles_and_dashboards" %>
 <% provide(:title, "つぶやき一覧") %>
 <% number_of_comment_notifications = @comment_notifications.count %>
 <% if number_of_comment_notifications > 0 %>

--- a/app/views/users/tweets/index_user.html.erb
+++ b/app/views/users/tweets/index_user.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag "users/index_articles_and_dashboards" %>
+<%= javascript_pack_tag "users/tweets", "users/index_articles_and_dashboards" %>
 <% provide(:title, "#{@user.name}のつぶやき一覧") %>
 <%= render "users/tweets/shared/tweets_table" %>
 <div id="new" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -1,3 +1,10 @@
+<button type="button" class="btn btn-success filter-modal-btn ml-3" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
+  絞り込み検索
+</button>
+<% if params[:reset] %>
+  <button type="button" class="btn btn-outline-success reset-btn ml-3">リセット</button>
+<% end %>
+
 <div class="content">
   <div class="container">
     <div class="row">
@@ -58,6 +65,50 @@
           <%= render 'users/shared/table_without_record' %>
         </div>
       <% end %>
+    </div>
+  </div>
+</div>
+
+
+<div class="modal fade" id="sortFilterModal" tabindex="-1" aria-labelledby="sortFilterModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="form-inline">
+        <h5 class="modal-title text-center flex-grow-1 mt-4" id="sortFilterModalLabel"></h5>
+        <button type="button" class="modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-right">
+        <div class="filter-modal" style="display: none;">
+          <div class="form-group row my-4">
+            <label for="input-author" class="col-sm-4 col-form-label"><%= Tweet.human_attribute_name(:tweet_contributor) %></label>
+            <div class="col-md-8">
+              <input type="text" aria-label="author" id="input-author" class="form-control" value="<%= params[:author] %>">
+            </div>
+            </div>
+          <div class="form-group row my-4">
+            <label for="input-title" class="col-sm-4 col-form-label"><%= Tweet.human_attribute_name(:post) %></label>
+            <div class="col-md-8">
+              <input type="text" aria-label="title" id="input-title" class="form-control" value="<%= params[:post] %>">
+            </div>
+          </div>
+          <div class="form-group row my-4">
+            <label for="input-created" class="col-sm-3 col-form-label"><%= Tweet.human_attribute_name(:created_at) %></label>
+            <div class="col-md-9 form-inline">
+              <div class="col-md-5">
+                <input type="date" aria-label="created" id="input-start" class="form-control" value="<%= params[:start] %>">
+              </div>
+              <div class="offset-1 align-bottom">〜</div>
+              <div class="col-md-5">
+                <input type="date" aria-label="created" id="input-finish" class="form-control" value="<%= params[:finish] %>">
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="text-center">
+          <button type="button" class="btn btn-primary submit-btn"></button>
+          <button type="button" class="modal-close btn btn-secondary" data-bs-dismiss="modal">戻る</button>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -1,3 +1,6 @@
+<button type="button" class="btn btn-success sort-modal-btn ml-3" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
+  並べ替え
+</button>
 <button type="button" class="btn btn-success filter-modal-btn ml-3" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
   絞り込み検索
 </button>
@@ -81,21 +84,40 @@
         <button type="button" class="modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body text-right">
+        <div class="sort-modal" style="display: none;">
+          <div class="form-group row my-5">
+            <label for="sort-select" class="col-sm-3 col-form-label"><%= Tweet.human_attribute_name(:created_at) %></label>
+            <div class="col-md-9">
+              <% order = {'DESC': '新しい順', 'ASC': '古い順'} %>
+              <% params[:order] ||= 'DESC' %>
+              <select id="sort-select" class="form-select" aria-label="Default select desc">
+                <option value="<%= params[:order] %>" selected><%= order.delete(:"#{params[:order]}") %></option>
+                <option value="<%= order.keys[0] %>"><%= order[order.keys[0]] %></option>
+              </select>
+            </div>
+          </div>
+        </div>
         <div class="filter-modal" style="display: none;">
           <div class="form-group row my-4">
-            <label for="input-author" class="col-sm-4 col-form-label"><%= Tweet.human_attribute_name(:tweet_contributor) %></label>
+            <label for="input-author" class="col-sm-4 col-form-label">
+              <%= Tweet.human_attribute_name(:author) %>
+            </label>
             <div class="col-md-8">
               <input type="text" aria-label="author" id="input-author" class="form-control" value="<%= params[:author] %>">
             </div>
-            </div>
+          </div>
           <div class="form-group row my-4">
-            <label for="input-title" class="col-sm-4 col-form-label"><%= Tweet.human_attribute_name(:post) %></label>
+            <label for="input-post" class="col-sm-4 col-form-label">
+              <%= Tweet.human_attribute_name(:post) %>
+            </label>
             <div class="col-md-8">
-              <input type="text" aria-label="title" id="input-title" class="form-control" value="<%= params[:post] %>">
+              <input type="text" aria-label="post" id="input-post" class="form-control" value="<%= params[:post] %>">
             </div>
           </div>
           <div class="form-group row my-4">
-            <label for="input-created" class="col-sm-3 col-form-label"><%= Tweet.human_attribute_name(:created_at) %></label>
+            <label for="input-created" class="col-sm-3 col-form-label">
+              <%= Tweet.human_attribute_name(:created_at) %>
+            </label>
             <div class="col-md-9 form-inline">
               <div class="col-md-5">
                 <input type="date" aria-label="created" id="input-start" class="form-control" value="<%= params[:start] %>">
@@ -115,3 +137,5 @@
     </div>
   </div>
 </div>
+
+<% binding.pry %>

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -137,5 +137,3 @@
     </div>
   </div>
 </div>
-
-<% binding.pry %>

--- a/config/locales/ja_tweet.yml
+++ b/config/locales/ja_tweet.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      tweet: 'つぶやき'
+    attributes:
+      tweet:
+        post: '投稿内容'
+        created_at: '投稿日時'
+        updated_at: '編集日時'
+        tweet_contributor: '投稿者'
+

--- a/config/locales/ja_tweet.yml
+++ b/config/locales/ja_tweet.yml
@@ -7,5 +7,5 @@ ja:
         post: '投稿内容'
         created_at: '投稿日時'
         updated_at: '編集日時'
-        tweet_contributor: '投稿者'
+        author: '投稿者'
 


### PR DESCRIPTION
### つぶやき一覧画面　並べ替えボタンと絞込み検索ボタンの実装

画面遷移イメージ
https://docs.google.com/spreadsheets/d/1-rdyXU23s2jkF2HsJrvWDOB0iw0k6O46wqIQ4ek6aAg/edit#gid=0

仕様書の9行目〜19行目の機能を実装しています。
https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=29885647

- つぶやき一覧を投稿日時が新しい順（DESC）、古い順（ASC）で並び替えできる。
- つぶやき一覧を投稿者、投稿内容の一部を指定してあいまい検索で絞込み表示ができる。
- 指定した投稿日時の範囲に投稿されたつぶやきを絞って表示できる。

レビューよろしくお願いします。