### PR TITLE
問い合わせ詳細画面

### DIFF
--- a/app/controllers/admins/inquiries_controller.rb
+++ b/app/controllers/admins/inquiries_controller.rb
@@ -9,7 +9,7 @@ module Admins
     end
 
     def show
-      @inquiry = Inquiry.find(params[:id])
+      @inquiries = Inquiry.find(params[:id])
     end
 
     def update

--- a/app/controllers/admins/inquiries_controller.rb
+++ b/app/controllers/admins/inquiries_controller.rb
@@ -9,7 +9,7 @@ module Admins
     end
 
     def show
-      @inquiries = Inquiry.find(params[:id])
+      @inquiry = Inquiry.find(params[:id])
     end
 
     def update

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,3 +6,4 @@
 // import '../javascript/application'
 import './count';
 import './count_t';
+import '../stylesheets/users/inquiries.scss';

--- a/app/javascript/stylesheets/users/inquiries.scss
+++ b/app/javascript/stylesheets/users/inquiries.scss
@@ -1,0 +1,6 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/views/admins/inquiries/index.html.erb
+++ b/app/views/admins/inquiries/index.html.erb
@@ -33,7 +33,7 @@
             <td>
               <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px">︙</button>
               <ul class="dropdown-menu">
-                <li><%= link_to 'やり取り', admins_inquiries_path(inquiry), class:"nav-link" %></li>
+                <li><%= link_to '詳細', admins_inquiry_path(inquiry), class:"nav-link" %></li>
                 <li><%= link_to '非表示', admins_inquiry_path(inquiry), method: :patch, class:"nav-link", data: { confirm: '本当に非表示にしますか？' } %></li>
               </ul>
             </td>

--- a/app/views/admins/inquiries/show.html.erb
+++ b/app/views/admins/inquiries/show.html.erb
@@ -5,13 +5,13 @@
 
     <div class="field">
         <label>件名</label>
-        <textarea id="subject" name="subject" rows="2" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiries.subject %></textarea>
+        <textarea id="subject" name="subject" rows="2" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiry.subject %></textarea>
     </div>
 
     
     <div class="field">
         <label>内容</label>
-        <textarea id="content" name="content" rows="9" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiries.content %></textarea>
+        <textarea id="content" name="content" rows="9" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiry.content %></textarea>
     </div>
 </div>
 

--- a/app/views/admins/inquiries/show.html.erb
+++ b/app/views/admins/inquiries/show.html.erb
@@ -10,7 +10,7 @@
 
     
     <div class="field">
-        <label>内容aa</label>
+        <label>内容</label>
         <textarea id="content" name="content" rows="9" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiries.content %></textarea>
     </div>
 </div>

--- a/app/views/admins/inquiries/show.html.erb
+++ b/app/views/admins/inquiries/show.html.erb
@@ -10,7 +10,7 @@
 
     
     <div class="field">
-        <label>内容</label>
+        <label>内容aa</label>
         <textarea id="content" name="content" rows="9" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiries.content %></textarea>
     </div>
 </div>

--- a/app/views/admins/inquiries/show.html.erb
+++ b/app/views/admins/inquiries/show.html.erb
@@ -1,0 +1,19 @@
+<h1 style="text-align:center;">お問い合わせ</h1>
+<br>
+
+<div style="text-align:center;">
+
+    <div class="field">
+        <label>件名</label>
+        <textarea id="subject" name="subject" rows="2" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiries.subject %></textarea>
+    </div>
+
+    
+    <div class="field">
+        <label>内容</label>
+        <textarea id="content" name="content" rows="9" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiries.content %></textarea>
+    </div>
+</div>
+
+
+


### PR DESCRIPTION
概要
問い合わせ詳細画面の作成

タスク・仕様書
https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=158420174
https://trello.com/c/7YzndklT/294-%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B%E6%A9%9F%E8%83%BD-%E8%A9%B3%E7%B4%B0%E7%94%BB%E9%9D%A2

実装内容・手法
①問い合わせ一覧3点リーダーの[やり取り]から[詳細]に変更。
②問い合わせ詳細ページから問い合わせ内容を見れるように変更。

添付ファイル
<img width="339" alt="スクリーンショット 2023-09-18 14 30 03" src="https://github.com/nishinotakay/teac-output-new/assets/10578
<img width="938" alt="スクリーンショット 2023-09-18 14 27 41" src="https://github.com/nishinotakay/teac-output-new/assets/105785155/2da430af-26b0-40b2-b3de-6df7193820c7">
5155/3a4fc288-6a0d-4885-aa3f-beb16b7cb202">
