### PR TITLE
Fix/tweet index n+1

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -55,22 +55,7 @@ module Users
 
     def index_user
       @user = User.find(params[:id])
-      filter = {
-        author: params[:author],
-        post: params[:post],
-        start: params[:start],
-        finish: params[:finish],
-        order: params[:order] || 'DESC'
-      }
-
-      @tweets = filter.compact.blank? ? base_tweets_queries.where(user_id: params[:id]).order(created_at: params[:order]) : base_tweets_queries.where(user_id: params[:id]).sort_filter(filter)
-
-      @tweets_with_images = @tweets.map do |tweet|
-        {
-          tweet: tweet,
-          image: tweet.user.profile&.image || "user_default.png"
-        }
-      end
+      fetch_tweets_and_images(@user.id)
     end
 
 
@@ -81,9 +66,10 @@ module Users
       params.require(:tweet).permit(:post, images: [])
     end
 
-    def fetch_tweets_and_images
+    def fetch_tweets_and_images(user_id = nil)
       filter = build_filter_from_params
-      @tweets = filter.compact.blank? ? base_tweets_queries.order(created_at: params[:order]) : base_tweets_queries.sort_filter(filter)
+      base_query = user_id ? base_tweets_queries.where(user_id: user_id) : base_tweets_queries
+      @tweets = filter.compact.blank? ? base_query.order(created_at: params[:order]) : base_query.sort_filter(filter)
       @tweets_with_images = @tweets.map do |tweet|
         {
           tweet: tweet,

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -9,22 +9,7 @@ module Users
     before_action :correct_tweet_user, only: %i[edit update destroy]
 
     def index
-      filter = {
-        author: params[:author],
-        post: params[:post],
-        start: params[:start],
-        finish: params[:finish],
-        order: params[:order] || 'DESC'
-      }
-
-      @tweets = filter.compact.blank? ? base_tweets_queries.order(created_at: params[:order]) : base_tweets_queries.sort_filter(filter)
-
-      @tweets_with_images = @tweets.map do |tweet|
-        {
-          tweet: tweet,
-          image: tweet.user.profile&.image || "user_default.png"
-        }
-      end
+      fetch_tweets_and_images
     end
 
     def show
@@ -94,6 +79,27 @@ module Users
 
     def tweet_params
       params.require(:tweet).permit(:post, images: [])
+    end
+
+    def fetch_tweets_and_images
+      filter = build_filter_from_params
+      @tweets = filter.compact.blank? ? base_tweets_queries.order(created_at: params[:order]) : base_tweets_queries.sort_filter(filter)
+      @tweets_with_images = @tweets.map do |tweet|
+        {
+          tweet: tweet,
+          image: tweet.user.profile&.image || "user_default.png"
+        }
+      end
+    end
+
+    def build_filter_from_params
+      {
+        author: params[:author],
+        post: params[:post],
+        start: params[:start],
+        finish: params[:finish],
+        order: params[:order] || 'DESC'
+      }
     end
 
     # 検索前のクエリを取得

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -82,7 +82,7 @@ module Users
     # 検索前のクエリを取得
     def base_tweets_queries
       Tweet.with_attached_images
-        .includes(:user, :profile, :tweet_comments)
+        .includes(:user, { user: [:profile, { profile: :image_attachment } ] }, :tweet_comments)
         .page(params[:page])
         .per(30)
     end
@@ -93,7 +93,6 @@ module Users
     end
 
     def correct_tweet_user
-      @tweet = Tweet.find(params[:id])
       if @tweet.user != current_user
         flash[:alert] = 'アクセスできません'
         redirect_to users_dash_boards_path

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -66,8 +66,7 @@ module Users
 
     def fetch_tweets_and_images(user_id = nil)
       filter = build_filter_from_params
-      base_query = user_id ? base_tweets_queries.where(user_id: user_id) : base_tweets_queries
-      @tweets = filter.compact.blank? ? base_query.order(created_at: params[:order]) : base_query.sort_filter(filter)
+      @tweets = Tweet.filtered_or_base_queries(filter, user_id, params[:page])
       @tweets_with_images = @tweets.map do |tweet|
         {
           tweet: tweet,
@@ -84,14 +83,6 @@ module Users
         finish: params[:finish],
         order:  params[:order] || 'DESC'
       }
-    end
-
-    # 検索前のクエリを取得
-    def base_tweets_queries
-      Tweet.with_attached_images
-        .includes(:user, { user: [:profile, { profile: :image_attachment }] }, :tweet_comments)
-        .page(params[:page])
-        .per(30)
     end
 
     # beforeフィルター

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -9,24 +9,25 @@ module Users
     before_action :correct_tweet_user, only: %i[edit update destroy]
 
     def index
-      params[:order] ||= 'DESC'
       filter = {
         author: params[:author],
         post: params[:post],
         start: params[:start],
-        finish: params[:finish]
+        finish: params[:finish],
+        order: params[:order] || 'DESC'
       }
 
-      if filter.compact.blank?
-        @tweets = Tweet.order(created_at: params[:order]).page(params[:page]).per(30)
-      else
-        filter[:order] = params[:order]
-        @tweets = Tweet.sort_filter(filter).page(params[:page]).per(30)
+      @tweets = filter.compact.blank? ? base_tweets_queries.order(created_at: params[:order]) : base_tweets_queries.sort_filter(filter)
+
+      @tweets_with_images = @tweets.map do |tweet|
+        {
+          tweet: tweet,
+          image: tweet.user.profile&.image || "user_default.png"
+        }
       end
     end
 
     def show
-      @tweet = Tweet.find(params[:id])
       @tweet_comments = @tweet.tweet_comments.all.order(created_at: :desc)
       @tweet_comment = current_user.tweet_comments.new
     end
@@ -53,7 +54,6 @@ module Users
 
     def update
       if @tweet.update(tweet_params)
-        @tweet.save
         flash[:success] = '編集成功しました。'
         redirect_to users_tweets_url
       else
@@ -79,6 +79,14 @@ module Users
       params.require(:tweet).permit(:post, images: [])
     end
 
+    # 検索前のクエリを取得
+    def base_tweets_queries
+      Tweet.with_attached_images
+        .includes(:user, :profile, :tweet_comments)
+        .page(params[:page])
+        .per(30)
+    end
+
     # beforeフィルター
     def set_tweet
       @tweet = Tweet.find(params[:id])
@@ -87,12 +95,8 @@ module Users
     def correct_tweet_user
       @tweet = Tweet.find(params[:id])
       if @tweet.user != current_user
-        if authenticate_user!
-          flash[:alart] = 'アクセスできません'
-          redirect_to users_dash_boards_path
-        else
-          redirect_to root_path
-        end
+        flash[:alert] = 'アクセスできません'
+        redirect_to users_dash_boards_path
       end
     end
   end

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -58,8 +58,6 @@ module Users
       fetch_tweets_and_images(@user.id)
     end
 
-
-
     private
 
     def tweet_params
@@ -73,7 +71,7 @@ module Users
       @tweets_with_images = @tweets.map do |tweet|
         {
           tweet: tweet,
-          image: tweet.user.profile&.image || "user_default.png"
+          image: tweet.user.profile&.image || 'user_default.png'
         }
       end
     end
@@ -81,17 +79,17 @@ module Users
     def build_filter_from_params
       {
         author: params[:author],
-        post: params[:post],
-        start: params[:start],
+        post:   params[:post],
+        start:  params[:start],
         finish: params[:finish],
-        order: params[:order] || 'DESC'
+        order:  params[:order] || 'DESC'
       }
     end
 
     # 検索前のクエリを取得
     def base_tweets_queries
       Tweet.with_attached_images
-        .includes(:user, { user: [:profile, { profile: :image_attachment } ] }, :tweet_comments)
+        .includes(:user, { user: [:profile, { profile: :image_attachment }] }, :tweet_comments)
         .page(params[:page])
         .per(30)
     end

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -69,9 +69,26 @@ module Users
     end
 
     def index_user
-      @tweets = Tweet.where(user_id: params[:id]).page(params[:page]).per(30)
       @user = User.find(params[:id])
+      filter = {
+        author: params[:author],
+        post: params[:post],
+        start: params[:start],
+        finish: params[:finish],
+        order: params[:order] || 'DESC'
+      }
+
+      @tweets = filter.compact.blank? ? base_tweets_queries.where(user_id: params[:id]).order(created_at: params[:order]) : base_tweets_queries.where(user_id: params[:id]).sort_filter(filter)
+
+      @tweets_with_images = @tweets.map do |tweet|
+        {
+          tweet: tweet,
+          image: tweet.user.profile&.image || "user_default.png"
+        }
+      end
     end
+
+
 
     private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,8 +7,7 @@ module ApplicationHelper
 
   # 危険性があるhtmlタグを除去、改行を<br>に置換、空白を半角スペースに置換、URLをリンク化。
   def format_and_linkify_text(str)
-    sanitized_str = sanitize(str)
-    sanitized_str.gsub!(/\r\n|\n|\r/, '<br>')
+    sanitized_str = sanitize(simple_format(str))
     sanitized_str.gsub!(/ /, '&nbsp;')
     linked_str = Rinku.auto_link(sanitized_str, :all, 'target="_blank"')
     linked_str.html_safe

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,7 +2,6 @@ class Tweet < ApplicationRecord
   belongs_to :user
   has_many :tweet_comments, dependent: :destroy # この行を追加
   has_many_attached :images
-  has_one :profile, through: :user
 
   validates :post, presence: true, length: { maximum: 255 }
   validate :image_count_validation, :image_size_varidation, :image_type_validation

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,6 +2,7 @@ class Tweet < ApplicationRecord
   belongs_to :user
   has_many :tweet_comments, dependent: :destroy # この行を追加
   has_many_attached :images
+  has_one :profile, through: :user
 
   validates :post, presence: true, length: { maximum: 255 }
   validate :image_count_validation, :image_size_varidation, :image_type_validation

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -18,6 +18,19 @@ class Tweet < ApplicationRecord
       .presence || Tweet.none
   end
 
+  def self.base_queries(page)
+    with_attached_images
+      .includes(:user, { user: [:profile, { profile: :image_attachment }] }, :tweet_comments)
+      .page(page) # ここでページ番号を指定
+      .per(30)
+  end
+
+  def self.filtered_or_base_queries(filter, user_id = nil, page = 1) # user_idとpageのデフォルト値を定める
+    base_query = user_id ? base_queries(page).where(user_id: user_id) : base_queries(page)
+    filter.compact.blank? ? base_query.order(created_at: filter[:order]) : base_query.sort_filter(filter)
+  end
+
+
   private
 
   def image_count_validation

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -13,7 +13,6 @@
     <div class="row">
       <% if @tweets.exists? %>
         <% @tweets_with_images.each do |data| %>
-        <%# @tweets.each do |tweet| %>
           <div class="col-12 col-sm-8 offset-sm-2">
             <div class="card tweets-index-item">
               <div class="d-flex align-items-center">

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -12,36 +12,38 @@
   <div class="container">
     <div class="row">
       <% if @tweets.exists? %>
-        <% @tweets.each do |tweet| %>
+        <% @tweets_with_images.each do |data| %>
+        <%# @tweets.each do |tweet| %>
           <div class="col-12 col-sm-8 offset-sm-2">
             <div class="card tweets-index-item">
-            <% image = tweet.user.profile.present? && tweet.user.profile.image.present? ? tweet.user.profile&.image : "user_default.png" %>
               <div class="d-flex align-items-center">
-                <%= image_tag image , class: "rounded-circle", size: "60x60" %>
+                  <% if data[:image].present? %>
+                    <%= image_tag data[:image] , class: "rounded-circle", size: "60x60" %>
+                  <% end %>
                 <div class="d-flex align-items-start flex-column justify-content-start"> <%# flex-colmunは縦並び %>
                   <div class="px-0">
-                    <%= link_to index_user_users_tweet_path(tweet.user_id), style: "text-decoration: underline;" do %>
-                      <strong><%= tweet.user.name %>&nbsp;</strong>
+                    <%= link_to index_user_users_tweet_path(data[:tweet].user_id), style: "text-decoration: underline;" do %>
+                      <strong><%= data[:tweet].user.name %>&nbsp;</strong>
                     <% end %>
                   </div>
-                  <time class="timestamp" data-time="<%= tweet.created_at.to_i %>"></time>
+                  <time class="timestamp" data-time="<%= data[:tweet].created_at.to_i %>"></time>
                 </div>
                 <div class="d-flex align-items-center ms-auto">
                   <div class="dropdown">
                     <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>
                     <ul class="dropdown-menu test-color">
-                      <li><%= link_to '詳細', index_user_users_tweet_path(tweet.user_id), class:"dropdown-item" %></li>
-                      <% if tweet.user.name == current_user.name %>
-                        <li><%= link_to '編集', edit_users_tweet_path(tweet), remote: true, class:"dropdown-item" %></li>
-                        <li><%= link_to '削除', users_tweet_path(tweet), method: :delete, data: { confirm: 'Are you sure?' }, class:"dropdown-item" %></li>
+                      <li><%= link_to '詳細', index_user_users_tweet_path(data[:tweet].user_id), class:"dropdown-item" %></li>
+                      <% if data[:tweet].user.name == current_user.name %>
+                        <li><%= link_to '編集', edit_users_tweet_path(data[:tweet]), remote: true, class:"dropdown-item" %></li>
+                        <li><%= link_to '削除', users_tweet_path(data[:tweet]), method: :delete, data: { confirm: 'Are you sure?' }, class:"dropdown-item" %></li>
                       <% end %>
                     </ul>
                   </div>
                 </div>
               </div>
-              <div class="tweet-post" data-tweet-url="<%= users_tweet_path(tweet.id) %>">
-                <%= raw Rinku.auto_link(sanitize(simple_format(tweet.post.gsub(/ /, '&nbsp;'))), :all, 'target="_blank"') %>
-                <% tweet.images.each do |image| %>
+              <div class="tweet-post" data-tweet-url="<%= users_tweet_path(data[:tweet].id) %>">
+                <%= format_and_linkify_text(data[:tweet].post) %>
+                <% data[:tweet].images.each do |image| %>
                   <% if image.persisted? %>
                     <%= image_tag image, class: "tweet-image" %>
                   <% end %>
@@ -49,10 +51,10 @@
               </div>
               <div class="d-flex align-items-center">
                 <div class="commentIcon px-2">
-                  <%= link_to users_tweet_path(tweet.id), style: "color: black; text-decoration: none;" do %>
+                  <%= link_to users_tweet_path(data[:tweet].id), style: "color: black; text-decoration: none;" do %>
                     <i class="fa-regular fa-comment fa-lg"></i>
-                    <% if tweet.tweet_comments.count > 0 %>
-                      &nbsp;<%= tweet.tweet_comments.count %>
+                    <% if data[:tweet].tweet_comments.size > 0 %>
+                      &nbsp;<%= data[:tweet].tweet_comments.size %>
                     <% end %>
                   <% end %>
                 </div>


### PR DESCRIPTION
### つぶやき一覧画面　N+1問題を解消

1. GET "/users/tweets"の挙動でidだけが異なるだけのSQLが多く発生していたので、tweets_controllerのindexアクション内で`Tweet.all`を取得していたものを`Tweet .includes(:user, { user: [:profile, { profile: :image_attachment } ] }, :tweet_comments)`に修正してN+1問題を解消しています。また、indexアクションの記述が長くなったのでプライベートメソッド`base_tweets_queries`を作成してます。


1. つぶやき一覧ビューページ（app/views/users/tweets/shared/_tweets_table.html.erb）にデータ取得のロジックを記述するとN+1問題の原因になるらしいので、従前`app/views/users/tweets/shared/_tweets_table.html.erb`の18行目付近に記述してたデータ取得のロジックをtweets_controllerの20~26行目に移動しています。

つぶやき一覧画面表示の場合、並べ替え実施の場合、絞り込み実施の場合で、DBのクエリログにidだけが異なるSQLが複数発生していないか確認お願いします。

ログのスクショを添付します。

[つぶやき一覧画面表示]
![スクリーンショット 2023-09-21 15 45 26](https://github.com/nishinotakay/teac-output-new/assets/99413634/a51fa00a-b4f2-425d-a48b-340c8daec768)

[並び替え実施]
![スクリーンショット 2023-09-21 15 44 40](https://github.com/nishinotakay/teac-output-new/assets/99413634/a5fbf3dc-df11-4e7a-9a0c-883b988af585)

[絞り込み検索実施]
![スクリーンショット 2023-09-21 15 47 43](https://github.com/nishinotakay/teac-output-new/assets/99413634/e822ae72-f5df-4067-bfa1-8858606e0fb5)