### PR TITLE
fix/move-filter-to-model

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -65,7 +65,7 @@ module Users
     end
 
     def fetch_tweets_and_images(user_id = nil)
-      filter = build_filter_from_params
+      filter = Tweet.build_filter(params)
       @tweets = Tweet.filtered_or_base_queries(filter, user_id, params[:page])
       @tweets_with_images = @tweets.map do |tweet|
         {
@@ -75,15 +75,6 @@ module Users
       end
     end
 
-    def build_filter_from_params
-      {
-        author: params[:author],
-        post:   params[:post],
-        start:  params[:start],
-        finish: params[:finish],
-        order:  params[:order] || 'DESC'
-      }
-    end
 
     # beforeフィルター
     def set_tweet

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -13,7 +13,7 @@ module Users
     end
 
     def show
-      @tweet_comments = @tweet.tweet_comments.all.order(created_at: :desc)
+      @tweet_comments = @tweet.tweet_comments.order(created_at: :desc)
       @tweet_comment = current_user.tweet_comments.new
     end
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -6,6 +6,16 @@ class Tweet < ApplicationRecord
   validates :post, presence: true, length: { maximum: 255 }
   validate :image_count_validation, :image_size_varidation, :image_type_validation
 
+  def self.build_filter(params)
+    {
+      author: params[:author],
+      post:   params[:post],
+      start:  params[:start],
+      finish: params[:finish],
+      order:  params[:order] || 'DESC'
+    }
+  end
+
   def self.sort_filter(filter)
     start = Time.zone.parse(filter[:start].presence || '2022-01-01').beginning_of_day
     finish = Time.zone.parse(filter[:finish].presence || Date.current.to_s).end_of_day

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -11,7 +11,7 @@
 <div class="content">
   <div class="container">
     <div class="row">
-      <% if @tweets.exists? %>
+      <% if @tweets.present? %>
         <% @tweets_with_images.each do |data| %>
           <div class="col-12 col-sm-8 offset-sm-2">
             <div class="card tweets-index-item">

--- a/app/views/users/tweets/shared/_tweets_table.html.erb
+++ b/app/views/users/tweets/shared/_tweets_table.html.erb
@@ -31,7 +31,7 @@
                   <div class="dropdown">
                     <button class="btn" data-bs-toggle="dropdown" style="width: 50px">︙</button>
                     <ul class="dropdown-menu test-color">
-                      <li><%= link_to '詳細', index_user_users_tweet_path(data[:tweet].user_id), class:"dropdown-item" %></li>
+                      <li><%= link_to '詳細', users_tweet_path(data[:tweet].id), class:"dropdown-item" %></li>
                       <% if data[:tweet].user.name == current_user.name %>
                         <li><%= link_to '編集', edit_users_tweet_path(data[:tweet]), remote: true, class:"dropdown-item" %></li>
                         <li><%= link_to '削除', users_tweet_path(data[:tweet]), method: :delete, data: { confirm: 'Are you sure?' }, class:"dropdown-item" %></li>


### PR DESCRIPTION
### パラメータの処理をモデルに移行

前回のMTGで話していた件です。

#### 作業内容
管理者のコントローラーでも使い回すことができるように、コントローラーに記述していたパラメーターの処理をモデルに移行しました。

#### 期待動作
以前と変わりません。
- 並び替えボタン押下で新しい順、古い順に並び替えができること
- 絞り込み検索ボタン押下で投稿者、投稿内容、投稿日時の絞り込み検索ができること

#### その他共有事項
前回指摘があった2点も今回のプルリクで修正しています。
- つぶやき一覧画面に表示されている3点リーダの詳細ボタンを押下すると投稿者のつぶやき一覧画面に遷移する問題
→修正後は詳細ボタンを押下すると、つぶやきのshowアクションビューに遷移するように修正しています。
- showアクションの修正 
修正前） `@tweet_comments = @tweet.tweet_comments.all.order(created_at: :desc)`
修正後）`@tweet_comments = @tweet.tweet_comments.order(created_at: :desc)`