### PR TITLE
fix/admins_users_controller_user_destroy

### DIFF
--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -23,8 +23,8 @@ module Admins
       @user = User.find(params[:format])
       if @user.destroy
         flash[:success] = "#{@user.name}のデータを削除しました。"
-        # 一覧ページへリダイレクト
-        redirect_to users_profiles_path
+        # ユーザー 一覧ページへリダイレクト
+        redirect_to admins_users_path
       else
         render :index
       end


### PR DESCRIPTION
▫️概要

下記のエラーを解消する。

・管理者ユーザーでログイン > 登録ユーザー一覧からユーザーを削除するとエラーが発生する 

———

▫️タスク・仕様書

https://trello.com/c/lSSdya7V

https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit#gid=0

———

▫️実装内容・手法

・user_destroyのリダイレクト先を登録ユーザー 一覧に変更した。

削除後のリダイレクト先が users_profiles_path (一般ユーザーのプロフィール一覧/ users/profiles#index) になっていたので、
リダイレクト先をadmins_users_pathに変更。削除後は、登録ユーザー一覧に遷移するようにした。

———

▫️確認事項

管理者ユーザーでログイン > 登録ユーザー一覧 に遷移して、ユーザーの削除が行えるか 確認をお願いします。
　　　　　　　　　　　　

