### PR TITLE
登録ユーザー更新エラーを解消

### DIFF
--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -20,9 +20,17 @@ module Admins
       @user = User.find(params[:id])
     end
 
+    def update
+      @user = User.find(params[:id])
+      if @user.update(users_params)
+        redirect_to admins_users_path, notice: 'ユーザー情報の更新が完了しました'
+      else
+        render :edit
+      end
+    end
+
     def destroy
       @user = User.find(params[:id])
-
       if @user.destroy
         flash[:success] = "#{@user.name}のデータを削除しました。"
         # ユーザー 一覧ページへリダイレクト
@@ -77,14 +85,6 @@ module Admins
       end
     end
 
-    def update
-      if @profile.update(profile_params)
-        redirect_to users_profile_path, notice: 'プロフィール情報の更新が完了しました'
-      else
-        render :edit
-      end
-    end
-
     private
 
     def find_profile
@@ -92,10 +92,8 @@ module Admins
       @profile = @user.profile
     end
 
-    def profile_params
-      params.require(:profile).permit(
-        :name, :learning_history, :purpose, :image, :created_at, :learning_start
-      )
+    def users_params
+      params.require(:user).permit(:name, :email, :password)
     end
   end
 end

--- a/app/views/admins/users/edit.html.erb
+++ b/app/views/admins/users/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, "ユーザー編集") %>
-<%= form_with model: @user, url: admins_user_path(@user), local: true do |f| %>
+<%= form_with model: @user, url: admins_user_path(@user), method: :patch, local: true do |f| %>
 
   <div class="form-group">
     <%= f.label :name, "名前" %><br/>
@@ -20,4 +20,3 @@
 <% end %>
 
 <%= link_to t('devise.shared.links.back'), :back %>
-


### PR DESCRIPTION
———

▫️概要

下記のエラーを解消する。

adminユーザー→登録ユーザー一覧→編集→更新でエラーが発生。エラーが出ないようにする。

———

▫️タスク・仕様書

https://trello.com/c/Me84KtyR

https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit#gid=0

———

▫️実装内容・手法

・Strong Parameterのモデル名とカラム名を修正(ユーザー編集フォームのname email passwordに合わせる)
・form_with にmethod: :patchを追加

———

▫️確認事項

・ユーザーの名前を変更して、更新ボタンをクリック、エラーが発生しないか確認する。
※ 更新のクリック時はpassword フォームに passwordを入力して下さい (一応、補足します)

——

▫️補足事項

２点補足します(長くなって申し訳ございません)

### @user = User.find(params[:id])は次回タスクで共通化します

・ @user = User.find(params[:id])が各アクションで繰り返されているので共通化したかったのですが、
　 before_actionのfind_profileで@user = User.find(params[:id]) と書かれておりました。
　
　そのため、次回のタスク「admin/users_controllerの@profile インスタンス変数を整理」でprofileがらみを削除、
　晴れて @user = User.find(params[:id])を共通化予定です。

----

下記については生澤さんから「一旦、こちらは保留で良いです」と判断していただきました。
そのため、今回は下記の事象について、対応はしておりません。

### ユーザー編集でメールアドレスを編集するとDeviseが確認用メールを送る機能が走ってしまう。　　　管理者のみでメールアドレスの変更をすることができない

管理者ユーザーで任意のユーザーのメールアドレスを更新しても、
Deviseの機能である確認用メールのURLを踏まないと、メールアドレスの変更を反映することができない状態です
(ユーザーの名前は変更できます)。

管理者のユーザー編集機能が、Deviseのモジュールの上に乗っかっているので、現状、管理者のみではメールアドレスの更新はできない状態です(編集したユーザーでログインして、letter_openerでメール確認して、リンクを踏むとメールアドレスの更新はされます)。
