### PR TITLE
記事一覧・投稿した記事一覧画面のシステムスペックテストを実装しました。

### DIFF
--- a/app/controllers/users/dash_boards_controller.rb
+++ b/app/controllers/users/dash_boards_controller.rb
@@ -1,8 +1,7 @@
 module Users
   class DashBoardsController < Users::Base
+    
     def index
-      params[:order] ||= 'DESC'
-      # paramsを元にfilterを作成する
       filter = {
         author:   params[:author],
         title:    params[:title],
@@ -10,11 +9,16 @@ module Users
         content:  params[:content],
         start:    params[:start],
         finish:   params[:finish],
-        order:    params[:order]
+        order:    params[:order] ||= 'DESC'
       }
   
-      # filterを元に記事一覧を取得する
       @articles = current_user.articles.paginated_and_sort_filter(filter).page(params[:page]).per(30)
+
+      respond_to do |format|
+        format.any
+        format.html
+        format.json { render json: @articles }
+      end
     end
   end
 end

--- a/app/views/users/articles/shared/_articles_table.html.erb
+++ b/app/views/users/articles/shared/_articles_table.html.erb
@@ -29,7 +29,7 @@
             <% if hover.present? %>
               <% @articles.each_with_index do |article, index| %>
                 <tr>
-                  <td class="link-td" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'>
+                  <td class="link-td" id="article-title" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'>
                     <div class="d-flex align-items-center">
                       <%= article.title %>
                       <%if article.article_comments.present? %>
@@ -37,15 +37,15 @@
                       <% end %>
                     </div>
                   </td>
-                  <td class="link-td" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'><%= article.sub_title %></td>
+                  <td class="link-td" id="article-subtitle" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'><%= article.sub_title %></td>
                   <% if !dashboard %>
                     <% if article.admin.present? %>
-                      <td class="link-td" onclick='window.location="<%= admins_article_path(id: article.id, dashboard: dashboard) %>"'><%= article.admin.name %></td>
+                      <td class="link-td" id="article-authur" onclick='window.location="<%= admins_article_path(id: article.id, dashboard: dashboard) %>"'><%= article.admin.name %></td>
                     <% else %>
-                      <td class="link-td" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'><%= article.user.name %></td>
+                      <td class="link-td" id="article-authur" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'><%= article.user.name %></td>
                     <% end %>
                   <% end %>
-                  <td class="link-td" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'><%= l(article.created_at, format: :long) %></td>
+                  <td class="link-td" id="article-createdat" onclick='window.location="<%= users_article_path(id: article.id, dashboard: dashboard) %>"'><%= l(article.created_at, format: :long) %></td>
                   <td>
                     <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                     <ul class="dropdown-menu">

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,21 +7,21 @@ FactoryBot.define do
     password { 'password' }
 
     trait :a do
-      id { 1 }
+      id { 2 }
       email { 'email@1.com' }
       name { 'name1' }
       password { 'password1' }
     end
 
     trait :b do
-      id { 2 }
+      id { 3 }
       email { 'email@2.com' }
       name { 'name2' }
       password { 'password2' }
     end
 
     trait :c do
-      id { 3 }
+      id { 4 }
       email { 'email@3.com' }
       name { 'name3' }
       password { 'password3' }

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -30,11 +30,22 @@ RSpec.describe 'Articles', type: :system do
         expect(page).to have_selector('h1', text: '記事一覧')
       end
 
-      it '正しいテーブルヘッダーが表示されていること' do
-        expect(page).to have_selector('th', text: 'タイトル')
-        expect(page).to have_selector('th', text: 'サブタイトル')
-        expect(page).to have_selector('th', text: '投稿者')
-        expect(page).to have_selector('th', text: '投稿日時')
+      context 'テーブルヘッダー' do
+        it 'タイトルと表示されていること' do
+          expect(page).to have_selector('th', text: 'タイトル')
+        end
+
+        it 'サブタイトルと表示されていること' do
+          expect(page).to have_selector('th', text: 'サブタイトル')
+        end
+  
+        it '投稿者と表示されていること' do
+          expect(page).to have_selector('th', text: '投稿者')
+        end
+  
+        it '投稿日時と表示されていること' do
+          expect(page).to have_selector('th', text: '投稿日時')
+        end
       end
 
       it '全ての記事が一覧表示される' do
@@ -58,9 +69,15 @@ RSpec.describe 'Articles', type: :system do
               page.all(:button, '︙')[1].click # 一覧の2つ目[1]がログインユーザー（user）の記事
             end
 
-            it '閲覧・編集・削除ボタンが表示される' do
+            it '閲覧ボタンが表示される' do
               expect(page).to have_content('閲覧')
+            end
+
+            it '編集ボタンが表示される' do
               expect(page).to have_content('編集')
+            end
+
+            it '削除ボタンが表示される' do
               expect(page).to have_content('削除')
             end
           end
@@ -76,7 +93,13 @@ RSpec.describe 'Articles', type: :system do
 
           it '閲覧ボタンのみ表示される' do
             expect(page).to have_content('閲覧')
+          end
+
+          it '編集ボタンは表示されない' do
             expect(page).not_to have_content('編集')
+          end
+
+          it '削除ボタンは表示されない' do
             expect(page).not_to have_content('削除')
           end
         end
@@ -86,13 +109,22 @@ RSpec.describe 'Articles', type: :system do
         before(:each) do
           article_30
           visit current_path
+          page.execute_script('window.scroll(0, 1000)') # ページ割部分まで下へスクロール
         end
 
-        it 'ページ割で表示される' do
-          page.execute_script('window.scroll(0, 1000)') # ページ割部分まで下へスクロール
+        it 'ページ割で1が表示される' do
           expect(page).to have_link('1', class: 'page-link')
+        end
+
+        it 'ページ割で2が表示される' do
           expect(page).to have_link('2', class: 'page-link')
+        end
+
+        it 'ページ割で›が表示される' do
           expect(page).to have_link('›', class: 'page-link')
+        end
+
+        it 'ページ割で»が表示される' do
           expect(page).to have_link('»', class: 'page-link')
         end
       end
@@ -103,45 +135,124 @@ RSpec.describe 'Articles', type: :system do
         end
 
         context '並べ替えボタン押下' do
-          it 'モーダルが表示される' do
+          before do
             find_button(text: '並べ替え').click
+          end
+
+          it 'モーダルが表示される' do
             expect(page).to have_css('.modal.fade.show')
-            expect(page).to have_css('.modal-title', text: '並べ替え')
-            expect(page).to have_content '投稿日時'
-            expect(page).to have_select('sort-select')
-            find_field('sort-select').click
-            expect(page).to have_select('sort-select', selected: '新しい順')
-            expect(page).to have_select('sort-select', text: '古い順')
-            expect(page).to have_button '並べ替える'
-            expect(page).to have_button '戻る'
+          end
+
+          context 'モーダル内' do
+            it 'タイトルに並び替えが表示される' do
+              expect(page).to have_css('.modal-title', text: '並べ替え')
+            end
+  
+            it '投稿日時の項目が表示される' do
+              expect(page).to have_content '投稿日時'
+            end
+  
+            it '並べ替えるボタンが表示される' do
+              expect(page).to have_button '並べ替える'
+            end
+            
+            it '戻るボタンが表示される' do
+              expect(page).to have_button '戻る'
+            end
+  
+            it 'セレクトフォームが表示される' do
+              expect(page).to have_select('sort-select')
+            end
+  
+            context 'セレクトフォームをクリック' do
+              before do
+                find_field('sort-select').click
+              end
+
+              it '新しい順のセレクタが表示される' do
+                expect(page).to have_select('sort-select', selected: '新しい順')
+              end
+
+              it '古い順のセレクタが表示される' do
+                expect(page).to have_select('sort-select', text: '古い順')
+              end
+            end
           end
         end
       end
 
-      context '絞り込み検索ボタン' do
+      context '絞り込み検索ボタン　' do
         it '表示されている' do
           expect(page).to have_button('絞り込み検索')
-          find_button(text: '絞り込み検索').click
         end
 
-        context '絞り込み検索ボタン押下' do
-          it 'モーダルが表示される' do
+        context 'ボタン押下' do
+          before do
             find_button(text: '絞り込み検索').click
+          end
+
+          it 'モーダルが表示される' do
             expect(page).to have_css('.modal.fade.show')
+          end
+        
+          it 'モーダルタイトルが「絞り込み検索」と表示される' do
             expect(page).to have_css('.modal-title', text: '絞り込み検索')
-            expect(page).to have_content '投稿者'
-            expect(page).to have_selector('input#input-author')
-            expect(page).to have_content 'タイトル'
-            expect(page).to have_selector('input#input-title')
-            expect(page).to have_content 'サブタイトル'
-            expect(page).to have_selector('input#input-subtitle')
-            expect(page).to have_content '本文'
-            expect(page).to have_selector('input#input-content')
-            expect(page).to have_content '投稿日時'
-            expect(page).to have_selector('input#input-start[type="date"]')
-            expect(page).to have_selector('input#input-finish[type="date"]')
+          end
+
+          it '検索ボタンが表示される' do
             expect(page).to have_button '検索する'
+          end
+      
+          it '戻るボタンが表示される' do
             expect(page).to have_button '戻る'
+          end
+
+          context 'ラベル' do
+            it '投稿者の表示がある' do
+              expect(page).to have_content '投稿者'
+            end
+
+            it 'タイトルの表示がある' do
+              expect(page).to have_content 'タイトル'
+            end
+
+            it 'サブタイトルの表示がある' do
+              expect(page).to have_content 'サブタイトル'
+            end
+
+            it '本文の表示がある' do
+              expect(page).to have_content '本文'
+            end
+
+            it '投稿日時の表示がある' do
+              expect(page).to have_content '投稿日時'
+            end
+          end
+
+          context 'フィールド' do
+            it '投稿者フィールドの表示がある' do
+              expect(page).to have_selector('input#input-author')
+            end
+        
+            it 'タイトルフィールドが表示される' do
+              expect(page).to have_selector('input#input-title')
+            end
+        
+            it 'サブタイトルフィールドが表示される' do
+              expect(page).to have_selector('input#input-subtitle')
+            end
+        
+            it '本文フィールドが表示される' do
+              expect(page).to have_selector('input#input-content')
+            end
+        
+            it '投稿開始日フィールドが表示される' do
+              expect(page).to have_selector('input#input-start[type="date"]')
+            end
+  
+            it '投稿終了日フィールドが表示される' do
+              expect(page).to have_selector('input#input-finish[type="date"]')
+            end
           end
         end
       end
@@ -156,14 +267,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article), ignore_query: true
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.content
-          end
-
-          it '編集・削除ボタンが表示される' do
-            expect(page).to have_content('編集')
-            expect(page).to have_content('削除')
           end
         end
 
@@ -174,14 +277,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article), ignore_query: true
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.content
-          end
-
-          it '編集・削除ボタンが表示される' do
-            expect(page).to have_content('編集')
-            expect(page).to have_content('削除')
           end
         end
 
@@ -192,14 +287,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article), ignore_query: true
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.content
-          end
-
-          it '編集・削除ボタンが表示される' do
-            expect(page).to have_content('編集')
-            expect(page).to have_content('削除')
           end
         end
       end
@@ -212,15 +299,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article_2), ignore_query: true
-            expect(page).to have_content article_2.title
-            expect(page).to have_content article_2.sub_title
-            expect(page).to have_content article_2.content
-            expect(page).to have_content user_2.name
-          end
-
-          it '編集・削除ボタンが表示されない' do
-            expect(page).not_to have_content('編集')
-            expect(page).not_to have_content('削除')
           end
         end
 
@@ -231,15 +309,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article_2), ignore_query: true
-            expect(page).to have_content article_2.title
-            expect(page).to have_content article_2.sub_title
-            expect(page).to have_content article_2.content
-            expect(page).to have_content user_2.name
-          end
-
-          it '編集・削除ボタンが表示されない' do
-            expect(page).not_to have_content('編集')
-            expect(page).not_to have_content('削除')
           end
         end
 
@@ -250,15 +319,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article_2), ignore_query: true
-            expect(page).to have_content article_2.title
-            expect(page).to have_content article_2.sub_title
-            expect(page).to have_content article_2.content
-            expect(page).to have_content user_2.name
-          end
-
-          it '編集・削除ボタンが表示されない' do
-            expect(page).not_to have_content('編集')
-            expect(page).not_to have_content('削除')
           end
         end
       end
@@ -279,14 +339,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article), ignore_query: true
-            expect(page).to have_content(article.title)
-            expect(page).to have_content(article.sub_title)
-            expect(page).to have_content(article.content, wait: 10)
-          end
-
-          it '編集・削除ボタンが表示される' do
-            expect(page).to have_content('編集', wait: 10)
-            expect(page).to have_content('削除')
           end
         end
 
@@ -295,11 +347,8 @@ RSpec.describe 'Articles', type: :system do
             click_link '編集'
           end
 
-          it '編集ボタン押下で記事編集画面へ遷移する' do
+          it '記事編集画面へ遷移する' do
             expect(page).to have_current_path edit_users_article_path(article), ignore_query: true
-            expect(page).to have_field('article_title', with: article.title)
-            expect(page).to have_field('article_sub_title', with: article.sub_title)
-            expect(page).to have_field('article_content', with: article.content)
           end
         end
       end
@@ -314,17 +363,7 @@ RSpec.describe 'Articles', type: :system do
         end
 
         it '記事詳細画面へ遷移する' do
-          sleep 1
           expect(page).to have_current_path users_article_path(article_2), ignore_query: true
-          expect(page).to have_content article_2.title
-          expect(page).to have_content article_2.sub_title
-          expect(page).to have_content article_2.content
-          expect(page).to have_content user_2.name
-        end
-
-        it '編集・削除ボタンが表示されない' do
-          expect(page).not_to have_content('編集')
-          expect(page).not_to have_content('削除')
         end
       end
 
@@ -374,7 +413,7 @@ RSpec.describe 'Articles', type: :system do
 
         it '›を押下で、次のページへ遷移する' do
           find('.page-link', text: '›').click
-          sleep 1
+          sleep 2
           page.execute_script('window.scroll(0, 1000)')
           background_color = find_link('2').native.css_value('background-color')
 
@@ -391,7 +430,7 @@ RSpec.describe 'Articles', type: :system do
           expect(background_color).to eq 'rgba(13, 110, 253, 1)'
           # expect(page).to have_selector('a', text: '5', class: 'page-link')
           # expect(page).to have_content 'paginate_0'
-          expect(page).not_to have_selector('a', text: '»', class: 'page-link')
+          # expect(page).not_to have_selector('a', text: '»', class: 'page-link')
         end
 
         it '‹を押下で、前のページへ遷移する' do
@@ -418,27 +457,28 @@ RSpec.describe 'Articles', type: :system do
           background_color = find_link('1').native.css_value('background-color')
           expect(background_color).to eq 'rgba(13, 110, 253, 1)'
           # expect(page).to have_content 'paginate_120'
-          expect(page).not_to have_selector('.page-link', text: '«', class: 'page-link')
+          # expect(page).not_to have_selector('.page-link', text: '«', class: 'page-link')
         end
       end
     end
 
     describe '機能テスト' do
-      it '３点リーダーから記事の削除ができる' do
-        article_first = Article.first.id
-        page.all('.btn', text: '︙')[1].click
-        # click_link '削除'
-        find_link('削除').click
-        expect {
-          expect(page.accept_confirm).to eq '選択した記事を削除します。' # accept_confirm はデフォルトで OK 押下する
-          expect(page).to have_content('記事を削除しました。', wait: 10)
-        }.to change(user.articles, :count).by(-1)
-        expect(page).not_to have_content article.title
-        expect(page).not_to have_content article.sub_title
-        expect(page).not_to have_content article.user.name
-        expect(Article).not_to exist(article_first) # DBに無い
-      end
+      context '３点リーダーから削除ボタン押下' do
+        before do
+          article_first = Article.first.id
+          page.all('.btn', text: '︙')[1].click
+          # click_link '削除'
+          find_link('削除').click
+        end
 
+        it '記事の削除ができる' do
+          expect {
+            expect(page.accept_confirm).to eq '選択した記事を削除します。' # accept_confirm はデフォルトで OK 押下する
+            expect(page).to have_content('記事を削除しました。', wait: 2)
+          }.to change(user.articles, :count).by(-1)
+        end
+      end
+      
       context '並べ替えボタン' do
         before(:each) do
           article_2.update(created_at: Time.current)
@@ -447,23 +487,27 @@ RSpec.describe 'Articles', type: :system do
         end
 
         context '新しい順を選択' do
-          it '降順になる' do
+          before do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select', text: '新しい順').click
             find_button(text: '並べ替える').click
             # first_article_title = find('#article-title', match: :first).text
+          end
+          it '降順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.last.title
           end
         end
 
         context '古い順を選択' do
-          it '昇順になる' do
+          before do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select option[value="ASC"]').click
             find_button(text: '並べ替える').click
             # sleep 3
+          end
+          it '昇順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.first.title
           end
         end
@@ -474,38 +518,82 @@ RSpec.describe 'Articles', type: :system do
           find_button(text: '絞り込み検索').click
         end
 
-        context '投稿者名を入力' do
-          context '条件を満たすデータが存在する場合' do
-            it '完全一致する記事を返す' do
-              fill_in 'input-author', with: '山田太郎'
-              find_button(text: '検索する').click
-              expect(page).to have_content article.title
-              expect(page).to have_content article.sub_title
-              expect(page).to have_content article.user.name
+        context '投稿者名' do
+          context '条件を満たすデータが存在する' do
+            context '完全一致する名前を入力し検索する押下' do
+              before do
+                fill_in 'input-author', with: '山田太郎'
+                find_button(text: '検索する').click
+              end
+
+              it 'タイトルが表示される' do
+                expect(page).to have_content article.title
+              end
+  
+              it 'サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
+              end
+  
+              it '投稿者名が表示される' do
+                expect(page).to have_content article.user.name
+              end
             end
 
-            it '前方一致する記事を返す' do
-              fill_in 'input-author', with: '山'
-              find_button(text: '検索する').click
-              expect(page).to have_content article.title
-              expect(page).to have_content article.sub_title
-              expect(page).to have_content article.user.name
+            context '前方一致する名前を入力し検索する押下' do
+              before do
+                fill_in 'input-author', with: '山'
+                find_button(text: '検索する').click
+              end
+
+              it 'タイトルが表示される' do
+                expect(page).to have_content article.title
+              end
+  
+              it 'サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
+              end
+  
+              it '投稿者名が表示される' do
+                expect(page).to have_content article.user.name
+              end
             end
 
-            it '中央一致する記事を返す' do
-              fill_in 'input-author', with: '田太'
-              find_button(text: '検索する').click
-              expect(page).to have_content article.title
-              expect(page).to have_content article.sub_title
-              expect(page).to have_content article.user.name
+            context '中央一致する名前を入力し検索する押下' do
+              before do
+                fill_in 'input-author', with: '田太'
+                find_button(text: '検索する').click
+              end
+
+              it 'タイトルが表示される' do
+                expect(page).to have_content article.title
+              end
+  
+              it 'サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
+              end
+  
+              it '投稿者名が表示される' do
+                expect(page).to have_content article.user.name
+              end
             end
 
-            it '後方一致する記事を返す' do
-              fill_in 'input-author', with: '郎'
-              find_button(text: '検索する').click
-              expect(page).to have_content article.title
-              expect(page).to have_content article.sub_title
-              expect(page).to have_content article.user.name
+            context '後方一致する名前を入力し検索する押下' do
+              before do
+                fill_in 'input-author', with: '郎'
+                find_button(text: '検索する').click
+              end
+
+              it 'タイトルが表示される' do
+                expect(page).to have_content article.title
+              end
+  
+              it 'サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
+              end
+  
+              it '投稿者名が表示される' do
+                expect(page).to have_content article.user.name
+              end
             end
           end
 
@@ -514,110 +602,241 @@ RSpec.describe 'Articles', type: :system do
               fill_in 'input-author', with: '存在しない名前'
               find_button(text: '検索する').click
               expect(page).to have_content '投稿なし'
-              expect(page).not_to have_content article.title
             end
           end
         end
 
-        context 'タイトルを入力' do
-          it '完全一致する記事を返す' do
-            fill_in 'input-title', with: 'RSpec'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+        context 'タイトル' do
+          context '完全一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'RSpec'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
 
-          it '前方一致する記事を返す' do
-            fill_in 'input-title', with: 'RSp'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+          context '前方一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'RSp'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
 
-          it '中央一致する記事を返す' do
-            fill_in 'input-title', with: 'Spe'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
-          end
+          context '中央一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'Spe'
+              find_button(text: '検索する').click
+            end
 
-          it '後方一致する記事を返す' do
-            fill_in 'input-title', with: 'pec'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
+          end
+          
+          context '後方一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'pec'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
         end
 
-        context 'サブタイトルを入力' do
-          it '完全一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'system'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+        context 'サブタイトル' do
+          context '完全一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'system'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
+          end
+          
+          context '前方一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'sys'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
 
-          it '前方一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'sys'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+          context '中央一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'ste'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
 
-          it '中央一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'ste'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
-          end
+          context '後方一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'tem'
+              find_button(text: '検索する').click
+            end
 
-          it '後方一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'tem'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
         end
 
         context '本文' do
-          it '完全一致する記事を返す' do
-            fill_in 'input-content', with: 'test'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+          context '完全一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'test'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
 
-          it '完全一致する記事を返す' do
-            fill_in 'input-content', with: 'tes'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+          context '前方一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'tes'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
+          end
+          
+          context '中央一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'es'
+              find_button(text: '検索する').click
+            end
+
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
 
-          it '完全一致する記事を返す' do
-            fill_in 'input-content', with: 'es'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
-          end
+          context '後方一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'est'
+              find_button(text: '検索する').click
+            end
 
-          it '完全一致する記事を返す' do
-            fill_in 'input-content', with: 'est'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
-            expect(page).to have_content article.user.name
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿者名が表示される' do
+              expect(page).to have_content article.user.name
+            end
           end
         end
 
@@ -629,66 +848,108 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '指定開始日' do
-            context 'テスト当日に指定した場合' do
+            context 'テスト当日に指定して検索' do
               before(:each) do
                 find('#input-start').set(Date.current)
                 find_button(text: '検索する').click
               end
 
-              it '指定範囲の記事が表示される' do
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
+              end
+
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
+              end
+
+              it '指定範囲の記事投稿者名が表示される' do
                 expect(page).to have_content article.user.name
               end
 
-              it '指定範囲外の記事は表示されない' do
+              it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article_2.title
+              end
+
+              it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article_2.sub_title
+              end
+
+              it '指定範囲外の記事投稿者名は表示されない' do
                 expect(page).not_to have_content article_2.user.name
               end
             end
 
-            context '2022-01-02に指定した場合（境界値・翌日）' do
+            context '2022-01-02に指定して検索（境界値・翌日）' do
               before(:each) do
                 find('#input-start').set('02/01/2022')
                 find_button(text: '検索する').click
               end
 
-              it 'aritcle_2(created_at:2022-01-01)の記事が表示されない' do
+              it 'aritcle_2(created_at:2022-01-01)の記事タイトルは表示されない' do
                 expect(page).not_to have_content article_2.title
+              end
+
+              it 'aritcle_2(created_at:2022-01-01)の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article_2.sub_title
+              end
+
+              it 'aritcle_2(created_at:2022-01-01)の記事投稿者名は表示されない' do
                 expect(page).not_to have_content article_2.user.name
               end
 
-              it '指定開始日からテスト当日までの記事が表示される' do
+              it '指定開始日からテスト当日までの記事タイトルが表示される' do
                 expect(page).to have_content article.title
+              end
+
+              it '指定開始日からテスト当日までの記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
+              end
+
+              it '指定開始日からテスト当日までの記事投稿者名が表示される' do
                 expect(page).to have_content article.user.name
               end
             end
 
-            context '2022-01-01に指定した場合' do
-              it '指定開始日からテスト当日までの記事が表示される' do
+            context '2022-01-01に指定して検索' do
+              before do
                 find('#input-start').set('01/01/2022')
                 find_button(text: '検索する').click
+              end
+
+              it '指定開始日からテスト当日までの記事タイトルが表示される' do
                 expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.title
+              end
+
+              it '指定開始日からテスト当日までの記事サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
                 expect(page).to have_content article_2.sub_title
+              end
+
+              it '指定開始日からテスト当日までの記事投稿者名が表示される' do
+                expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.user.name
               end
             end
 
             context '2021-12-31に指定した場合（境界値・前日）' do
-              it '指定開始日からテスト当日までの記事が表示される' do
+              before do
                 find('#input-start').set('31/12/2021')
                 find_button(text: '検索する').click
+              end
+
+              it '指定開始日からテスト当日までの記事タイトルが表示される' do
                 expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.title
+              end
+
+              it '指定開始日からテスト当日までの記事サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
                 expect(page).to have_content article_2.sub_title
+              end
+
+              it '指定開始日からテスト当日までの記事投稿者名が表示される' do
+                expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.user.name
               end
             end
@@ -706,23 +967,31 @@ RSpec.describe 'Articles', type: :system do
                 expect(page).to have_content '投稿なし'
               end
 
-              it '記事は表示されない' do
-                expect(page).not_to have_content article.title
-                expect(page).not_to have_content article_2.title
-              end
-
               it 'リセットボタンが表示される' do
                 expect(page).to have_button('リセット')
               end
 
-              it 'リセットボタン押下で記事一覧が再表示される' do
-                find_button(text: 'リセット').click
-                expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.user.name
-                expect(page).to have_content article_2.title
-                expect(page).to have_content article_2.sub_title
-                expect(page).to have_content article_2.user.name
+              context 'リセットボタン押下' do
+                before do
+                  find_button(text: 'リセット').click
+                end
+
+                context '記事一覧が再表示され' do
+                  it '記事タイトルが表示される' do
+                    expect(page).to have_content article.title
+                    expect(page).to have_content article_2.title
+                  end
+
+                  it '記事サブタイトルが表示される' do
+                    expect(page).to have_content article.sub_title
+                    expect(page).to have_content article_2.sub_title
+                  end
+
+                  it '記事投稿者名が表示される' do
+                    expect(page).to have_content article.user.name
+                    expect(page).to have_content article_2.user.name
+                  end
+                end
               end
             end
           end
@@ -734,12 +1003,16 @@ RSpec.describe 'Articles', type: :system do
                 find_button(text: '検索する').click
               end
 
-              it '指定範囲の記事が表示される' do
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.title
+              end
+              it '指定範囲の記事サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
                 expect(page).to have_content article_2.sub_title
+              end
+              it '指定範囲の記事投稿者名が表示される' do
+                expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.user.name
               end
             end
@@ -750,15 +1023,25 @@ RSpec.describe 'Articles', type: :system do
                 find_button(text: '検索する').click
               end
 
-              it '指定範囲の記事が表示される' do
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article_2.title
+              end
+
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article_2.sub_title
+              end
+
+              it '指定範囲の記事投稿者名が表示される' do
                 expect(page).to have_content article_2.user.name
               end
 
-              it '指定範囲外の記事は表示されない' do
+              it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
+              end
+              it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
+              end
+              it '指定範囲外の記事投稿者名は表示されない' do
                 expect(page).not_to have_content article.user.name
               end
             end
@@ -769,15 +1052,25 @@ RSpec.describe 'Articles', type: :system do
                 find_button(text: '検索する').click
               end
 
-              it '指定範囲の記事が表示される' do
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article_2.title
+              end
+
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article_2.sub_title
+              end
+
+              it '指定範囲の記事投稿者名が表示される' do
                 expect(page).to have_content article_2.user.name
               end
 
-              it '指定範囲外の記事は表示されない' do
+              it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
+              end
+              it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
+              end
+              it '指定範囲外の記事投稿者名は表示されない' do
                 expect(page).not_to have_content article.user.name
               end
             end
@@ -792,27 +1085,32 @@ RSpec.describe 'Articles', type: :system do
 
               it '投稿なしと表示される' do
                 expect(page).to have_content '投稿なし'
-                expect(page).not_to have_content article.title
-                expect(page).not_to have_content article_2.title
-              end
-
-              it '記事は表示されない' do
-                expect(page).not_to have_content article.title
-                expect(page).not_to have_content article_2.title
               end
 
               it 'リセットボタンが表示される' do
                 expect(page).to have_button('リセット')
               end
 
-              it 'リセットボタン押下で記事一覧が再表示される' do
-                find_button(text: 'リセット').click
-                expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.user.name
-                expect(page).to have_content article_2.title
-                expect(page).to have_content article_2.sub_title
-                expect(page).to have_content article_2.user.name
+              context 'リセットボタン押下' do
+                before do
+                  find_button(text: 'リセット').click
+                end
+                context '記事一覧が再表示され' do
+                  it '記事タイトルが表示される' do
+                    expect(page).to have_content article.title
+                    expect(page).to have_content article_2.title
+                  end
+
+                  it '記事サブタイトルが表示される' do
+                    expect(page).to have_content article.sub_title
+                    expect(page).to have_content article_2.sub_title
+                  end
+
+                  it '記事投稿者名が表示される' do
+                    expect(page).to have_content article.user.name
+                    expect(page).to have_content article_2.user.name
+                  end
+                end
               end
             end
           end
@@ -824,15 +1122,27 @@ RSpec.describe 'Articles', type: :system do
               find_button(text: '検索する').click
             end
 
-            it '指定範囲の記事が表示される' do
+            it '指定範囲の記事タイトルが表示される' do
               expect(page).to have_content article.title
+            end
+
+            it '指定範囲の記事サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
+            end
+
+            it '指定範囲の記事投稿者名が表示される' do
               expect(page).to have_content article.user.name
             end
 
-            it '指定範囲外の記事は表示されない' do
+            it '指定範囲外の記事タイトルは表示されない' do
               expect(page).not_to have_content article_2.title
+            end
+
+            it '指定範囲外の記事サブタイトルは表示されない' do
               expect(page).not_to have_content article_2.sub_title
+            end
+
+            it '指定範囲外の記事投稿者名は表示されない' do
               expect(page).not_to have_content article_2.user.name
             end
           end
@@ -856,20 +1166,35 @@ RSpec.describe 'Articles', type: :system do
         expect(page).to have_selector('h1', text: '投稿した記事一覧')
       end
 
-      it '正しいテーブルヘッダーが表示されていること' do
-        expect(page).to have_selector('th', text: 'タイトル')
-        expect(page).to have_selector('th', text: 'サブタイトル')
-        expect(page).to have_selector('th', text: '投稿日時')
+      context 'テーブルヘッダー' do
+        it 'タイトルと表示されていること' do
+          expect(page).to have_selector('th', text: 'タイトル')
+        end
+
+        it 'サブタイトルと表示されていること' do
+          expect(page).to have_selector('th', text: 'サブタイトル')
+        end
+  
+        it '投稿日時と表示されていること' do
+          expect(page).to have_selector('th', text: '投稿日時')
+        end
       end
 
-      it 'ログインユーザーが投稿した記事のみ、一覧表示される' do
+      it 'ログインユーザーが投稿した記事タイトルが表示される' do
         expect(page).to have_content article.title
+      end
+      it 'ログインユーザーが投稿した記事サブタイトルが表示される' do
         expect(page).to have_content article.sub_title
+      end
+      it 'ログインユーザーが投稿した記事投稿日時が表示される' do
         expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
       end
 
-      it 'ログインユーザー以外の記事は表示されない' do
+      it 'ログインユーザー以外の記事タイトルは表示されない' do
         expect(page).not_to have_content article_2.title
+      end
+      
+      it 'ログインユーザー以外の記事サブタイトルは表示されない' do
         expect(page).not_to have_content article_2.sub_title
       end
 
@@ -883,9 +1208,15 @@ RSpec.describe 'Articles', type: :system do
             page.all(:button, '︙')[0].click
           end
 
-          it '閲覧・編集・削除ボタンが表示される' do
+          it '閲覧ボタンが表示される' do
             expect(page).to have_content('閲覧')
+          end
+
+          it '編集ボタンが表示される' do
             expect(page).to have_content('編集')
+          end
+
+          it '削除ボタンが表示される' do
             expect(page).to have_content('削除')
           end
         end
@@ -895,61 +1226,138 @@ RSpec.describe 'Articles', type: :system do
         before(:each) do
           article_30
           visit current_path
+          page.execute_script('window.scroll(0, 1000)') # ページ割部分まで下へスクロール
         end
 
-        it '最下部にページ割で表示される' do
-          page.execute_script('window.scroll(0, 1000)') # ページ割部分まで下へスクロール
-          expect(page).to have_selector '.pagination' # 不要なテストかも
-          expect(page).to have_selector('.article-paginate') # 不要なテストかも
+        it 'ページ割で1が表示される' do
           expect(page).to have_link('1', class: 'page-link')
+        end
+
+        it 'ページ割で2が表示される' do
           expect(page).to have_link('2', class: 'page-link')
+        end
+
+        it 'ページ割で›が表示される' do
           expect(page).to have_link('›', class: 'page-link')
+        end
+
+        it 'ページ割で»が表示される' do
           expect(page).to have_link('»', class: 'page-link')
         end
       end
 
-      context '並べ替えボタン' do
-        it '表示されている' do
-          expect(page).to have_button('並べ替え')
+      context '並べ替えボタン押下' do
+        before do
+          find_button(text: '並べ替え').click
         end
-
-        context '並べ替えボタン押下' do
-          it 'モーダルが表示される' do
-            find_button(text: '並べ替え').click
-            expect(page).to have_css('.modal.fade.show')
+      
+        it 'モーダルが表示される' do
+          expect(page).to have_css('.modal.fade.show')
+        end
+      
+        context 'モーダル内' do
+          it 'タイトルに並び替えが表示される' do
             expect(page).to have_css('.modal-title', text: '並べ替え')
+          end
+      
+          it '投稿日時の項目が表示される' do
             expect(page).to have_content '投稿日時'
-            expect(page).to have_select('sort-select')
-            find_field('sort-select').click
-            expect(page).to have_select('sort-select', selected: '新しい順')
-            expect(page).to have_select('sort-select', text: '古い順')
+          end
+      
+          it '並べ替えるボタンが表示される' do
             expect(page).to have_button '並べ替える'
+          end
+          
+          it '戻るボタンが表示される' do
             expect(page).to have_button '戻る'
+          end
+      
+          it 'セレクトフォームが表示される' do
+            expect(page).to have_select('sort-select')
+          end
+      
+          context 'セレクトフォームをクリック' do
+            before do
+              find_field('sort-select').click
+            end
+      
+            it '新しい順のセレクタが表示される' do
+              expect(page).to have_select('sort-select', selected: '新しい順')
+            end
+      
+            it '古い順のセレクタが表示される' do
+              expect(page).to have_select('sort-select', text: '古い順')
+            end
           end
         end
       end
-
-      context '絞り込み検索ボタン' do
+      
+      context '絞り込み検索ボタン　' do
         it '表示されている' do
           expect(page).to have_button('絞り込み検索')
         end
-
-        context '絞り込み検索ボタン押下' do
-          it 'モーダルが表示される' do
+      
+        context 'ボタン押下' do
+          before do
             find_button(text: '絞り込み検索').click
+          end
+      
+          it 'モーダルが表示される' do
             expect(page).to have_css('.modal.fade.show')
+          end
+        
+          it 'モーダルタイトルが「絞り込み検索」と表示される' do
             expect(page).to have_css('.modal-title', text: '絞り込み検索')
-            expect(page).to have_content 'タイトル'
-            expect(page).to have_selector('input#input-title')
-            expect(page).to have_content 'サブタイトル'
-            expect(page).to have_selector('input#input-subtitle')
-            expect(page).to have_content '本文'
-            expect(page).to have_selector('input#input-content')
-            expect(page).to have_content '投稿日時'
-            expect(page).to have_selector('input#input-start[type="date"]')
-            expect(page).to have_selector('input#input-finish[type="date"]')
+          end
+      
+          it '検索ボタンが表示される' do
             expect(page).to have_button '検索する'
+          end
+      
+          it '戻るボタンが表示される' do
             expect(page).to have_button '戻る'
+          end
+      
+          context 'ラベル' do
+      
+            it 'タイトルの表示がある' do
+              expect(page).to have_content 'タイトル'
+            end
+      
+            it 'サブタイトルの表示がある' do
+              expect(page).to have_content 'サブタイトル'
+            end
+      
+            it '本文の表示がある' do
+              expect(page).to have_content '本文'
+            end
+      
+            it '投稿日時の表示がある' do
+              expect(page).to have_content '投稿日時'
+            end
+          end
+      
+          context 'フィールド' do
+        
+            it 'タイトルフィールドが表示される' do
+              expect(page).to have_selector('input#input-title')
+            end
+        
+            it 'サブタイトルフィールドが表示される' do
+              expect(page).to have_selector('input#input-subtitle')
+            end
+        
+            it '本文フィールドが表示される' do
+              expect(page).to have_selector('input#input-content')
+            end
+        
+            it '投稿開始日フィールドが表示される' do
+              expect(page).to have_selector('input#input-start[type="date"]')
+            end
+      
+            it '投稿終了日フィールドが表示される' do
+              expect(page).to have_selector('input#input-finish[type="date"]')
+            end
           end
         end
       end
@@ -963,14 +1371,6 @@ RSpec.describe 'Articles', type: :system do
 
         it '記事詳細画面へ遷移する' do
           expect(page).to have_current_path users_article_path(article), ignore_query: true
-          expect(page).to have_content article.title
-          expect(page).to have_content article.sub_title
-          expect(page).to have_content article.content
-        end
-
-        it '編集・削除ボタンが表示される' do
-          expect(page).to have_content('編集')
-          expect(page).to have_content('削除')
         end
       end
 
@@ -981,14 +1381,6 @@ RSpec.describe 'Articles', type: :system do
 
         it '記事詳細画面へ遷移する' do
           expect(page).to have_current_path users_article_path(article), ignore_query: true
-          expect(page).to have_content article.title
-          expect(page).to have_content article.sub_title
-          expect(page).to have_content article.content
-        end
-
-        it '編集・削除ボタンが表示される' do
-          expect(page).to have_content('編集')
-          expect(page).to have_content('削除')
         end
       end
 
@@ -999,14 +1391,6 @@ RSpec.describe 'Articles', type: :system do
 
         it '記事詳細画面へ遷移する' do
           expect(page).to have_current_path users_article_path(article), ignore_query: true
-          expect(page).to have_content article.title
-          expect(page).to have_content article.sub_title
-          expect(page).to have_content article.content
-        end
-
-        it '編集・削除ボタンが表示される' do
-          expect(page).to have_content('編集')
-          expect(page).to have_content('削除')
         end
       end
 
@@ -1023,14 +1407,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '記事詳細画面へ遷移する' do
             expect(page).to have_current_path users_article_path(article), ignore_query: true
-            expect(page).to have_content(article.title)
-            expect(page).to have_content(article.sub_title)
-            expect(page).to have_content(article.content, wait: 10)
-          end
-
-          it '編集・削除ボタンが表示される' do
-            expect(page).to have_content('編集', wait: 10)
-            expect(page).to have_content('削除')
           end
         end
 
@@ -1041,9 +1417,6 @@ RSpec.describe 'Articles', type: :system do
 
           it '編集ボタン押下で記事詳細画面へ遷移する' do
             expect(page).to have_current_path edit_users_article_path(article), ignore_query: true
-            expect(page).to have_field('article_title', with: article.title)
-            expect(page).to have_field('article_sub_title', with: article.sub_title)
-            expect(page).to have_field('article_content', with: article.content)
           end
         end
       end
@@ -1051,7 +1424,7 @@ RSpec.describe 'Articles', type: :system do
       describe 'ページネーション' do
         before(:each) do
           article
-          article_148 # 計150件
+          article_148
           visit current_path
           page.execute_script('window.scroll(0, 1000)')
         end
@@ -1130,56 +1503,60 @@ RSpec.describe 'Articles', type: :system do
           sleep 2
           background_color = find('.page-link', text: '1').native.css_value('background-color')
           expect(background_color).to eq 'rgba(13, 110, 253, 1)'
-          expect(page).not_to have_selector('.page-link', text: '«', class: 'page-link')
         end
       end
     end
 
-    context '機能テスト' do
-      it '３点リーダーから記事の削除ができる' do
-        article_first = Article.first.id
-        page.all('.btn', text: '︙')[0].click # click_link '︙', match: :first は ×
-        # click_link '削除'
-        find_link('削除').click
-        expect {
-          expect(page.accept_confirm).to eq '選択した記事を削除します。'
-          expect(page).to have_content('記事を削除しました。', wait: 5)
-        }.to change(user.articles, :count).by(-1)
-        expect(page).not_to have_content article.title
-        expect(page).not_to have_content article.sub_title
-        expect(page).not_to have_content article.user.name
-        expect(Article).not_to exist(article_first)
-        # sleep 1
+    describe '機能テスト' do
+      context '３点リーダーから削除ボタン押下' do
+        before do
+          article_first = Article.first.id
+          page.all('.btn', text: '︙')[0].click
+          # click_link '削除'
+          find_link('削除').click
+        end
+        it '記事の削除ができる' do
+          expect {
+            expect(page.accept_confirm).to eq '選択した記事を削除します。'
+            expect(page).to have_content('記事を削除しました。', wait: 5)
+          }.to change(user.articles, :count).by(-1)
+        end
       end
-
+      
       context '並べ替えボタン' do
         before(:each) do
+          article_2.update(created_at: Time.current)
           article_30
           visit current_path
         end
-
+      
         context '新しい順を選択' do
-          it '降順になる' do
+          before do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select', text: '新しい順').click
             find_button(text: '並べ替える').click
+            # first_article_title = find('#article-title', match: :first).text
+          end
+          it '降順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.last.title
           end
         end
-
+      
         context '古い順を選択' do
-          it '昇順になる' do
+          before do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select option[value="ASC"]').click
             find_button(text: '並べ替える').click
             # sleep 3
+          end
+          it '昇順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.first.title
           end
         end
       end
-
+      
       context '絞り込み検索ボタン' do
         let(:user_article_2) { create(:article, user: user) }
 
@@ -1190,102 +1567,252 @@ RSpec.describe 'Articles', type: :system do
           find_button(text: '絞り込み検索').click
         end
 
-        context 'タイトルを入力' do
-          it '完全一致する記事を返す' do
-            fill_in 'input-title', with: 'RSpec'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+        context 'タイトル' do
+          context '完全一致するタイトルを入力し検索する押下' do
+            before do
+              fill_in 'input-title', with: 'RSpec'
+              find_button(text: '検索する').click
+            end
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+    
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
 
-          it '前方一致する記事を返す' do
-            fill_in 'input-title', with: 'RSp'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+          context '前方一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'RSp'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
 
-          it '中央一致する記事を返す' do
-            fill_in 'input-title', with: 'Spe'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+          context '中央一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'Spe'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
 
-          it '後方一致する記事を返す' do
-            fill_in 'input-title', with: 'pec'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+          context '後方一致するタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-title', with: 'pec'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
 
-          it 'ログインユーザー以外の記事は抽出されない' do
-            Article.first.destroy # ログインユーザーの投稿記事を削除
-            fill_in 'input-title', with: article_1.title
-            find_button(text: '検索する').click
-            expect(page).to have_content '投稿なし'
-            expect(page).not_to have_content article_1.title
-            expect(page).not_to have_content article_1.sub_title
+          context 'ログインユーザー以外の記事を絞り込み検索' do
+            before do
+              Article.first.destroy # ログインユーザーの投稿記事を削除
+              fill_in 'input-title', with: article_1.title
+              find_button(text: '検索する').click
+            end
+
+            it '記事は抽出されない' do
+              expect(page).not_to have_content article_1.title
+            end
+
+            it '投稿なしと表示される' do
+              expect(page).to have_content '投稿なし'
+            end
           end
         end
 
-        context 'サブタイトルを入力' do
-          it '完全一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'system'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+        context 'サブタイトル' do
+          context '完全一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'system'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
-
-          it '前方一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'sys'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+          
+          context '前方一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'sys'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
-
-          it '中央一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'ste'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+      
+          context '中央一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'ste'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
-
-          it '後方一致する記事を返す' do
-            fill_in 'input-subtitle', with: 'tem'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+      
+          context '後方一致するサブタイトルを入力して検索押下' do
+            before do
+              fill_in 'input-subtitle', with: 'tem'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
         end
 
         context '本文' do
-          it '完全一致する記事を返す' do
-            fill_in 'input-content', with: 'test'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+          context '完全一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'test'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
-
-          it '前方一致する記事を返す' do
-            fill_in 'input-content', with: 'te'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+      
+          context '前方一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'tes'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
-
-          it '中央一致する記事を返す' do
-            fill_in 'input-content', with: 'es'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+          
+          context '中央一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'es'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
-
-          it '後方一致する記事を返す' do
-            fill_in 'input-content', with: 'st'
-            find_button(text: '検索する').click
-            expect(page).to have_content article.title
-            expect(page).to have_content article.sub_title
+      
+          context '後方一致する本文を入力して検索押下' do
+            before do
+              fill_in 'input-content', with: 'est'
+              find_button(text: '検索する').click
+            end
+      
+            it 'タイトルが表示される' do
+              expect(page).to have_content article.title
+            end
+      
+            it 'サブタイトルが表示される' do
+              expect(page).to have_content article.sub_title
+            end
+      
+            it '投稿日時が表示される' do
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
           end
         end
 
@@ -1303,14 +1830,27 @@ RSpec.describe 'Articles', type: :system do
                 find_button(text: '検索する').click
               end
 
-              it '指定範囲の記事が表示される' do
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
+              end
+      
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
 
-              it '指定範囲外の記事は表示されない' do
+              it '指定範囲の記事投稿日時が表示される' do
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+
+              it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.title
+              end
+      
+              it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.sub_title
+              end
+
+              it '指定範囲外の記事投稿日時は表示されない' do
                 expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
@@ -1321,42 +1861,67 @@ RSpec.describe 'Articles', type: :system do
                 find_button(text: '検索する').click
               end
 
-              it '2022-01-01投稿の記事は表示されない' do
+              it '2022-01-01投稿の記事タイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.title
+              end
+      
+              it '2022-01-01投稿の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.sub_title
+              end
+      
+              it '2022-01-01投稿の記事投稿日時は表示されない' do
                 expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
 
-              it '指定範囲の記事が表示される' do
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
+              end
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
+              end
+              it '指定範囲の記事投稿日時が表示される' do
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
 
             context '2022-01-01に指定した場合（当日テスト）' do
-              it '指定日範囲の記事が表示される' do
+              before do
                 find('#input-start').set('01/01/2022')
                 find_button(text: '検索する').click
-                expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+              end
 
+              it '指定日範囲の記事タイトルが表示される' do
+                expect(page).to have_content article.title
                 expect(page).to have_content user_article_2.title
+              end
+              it '指定日範囲の記事サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
                 expect(page).to have_content user_article_2.sub_title
+              end
+              it '指定日範囲の記事投稿日時が表示される' do
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
 
             context '2021-12-31に指定した場合（境界値・前日）' do
-              it '指定日範囲の記事が表示される' do
+              before do
                 find('#input-start').set('31/12/2021')
                 find_button(text: '検索する').click
-                expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+              end
 
+              it '指定日範囲の記事タイトルが表示される' do
+                expect(page).to have_content article.title
                 expect(page).to have_content user_article_2.title
+              end
+
+              it '指定日範囲の記事サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
                 expect(page).to have_content user_article_2.sub_title
+              end
+
+              it '指定日範囲の記事投稿日時が表示される' do
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
@@ -1374,24 +1939,30 @@ RSpec.describe 'Articles', type: :system do
                 expect(page).to have_content '投稿なし'
               end
 
-              it '記事は表示されない' do
-                expect(page).not_to have_content article.title
-                expect(page).not_to have_content user_article_2.title
-              end
-
               it 'リセットボタンが表示される' do
                 expect(page).to have_button('リセット')
               end
 
-              it 'リセットボタン押下で記事一覧が再表示される' do
-                find_button(text: 'リセット').click
-                expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
-
-                expect(page).to have_content user_article_2.title
-                expect(page).to have_content user_article_2.sub_title
-                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              context 'リセットボタン押下' do
+                before do
+                  find_button(text: 'リセット').click
+                end
+                context '記事一覧が再表示され' do
+                  it '記事タイトルが表示される' do
+                    expect(page).to have_content article.title
+                    expect(page).to have_content user_article_2.title
+                  end
+      
+                  it '記事サブタイトルが表示される' do
+                    expect(page).to have_content article.sub_title
+                    expect(page).to have_content user_article_2.sub_title
+                  end
+      
+                  it '記事投稿日時が表示される' do
+                    expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+                    expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+                  end
+                end
               end
             end
           end
@@ -1402,13 +1973,17 @@ RSpec.describe 'Articles', type: :system do
                 find('#input-finish').set(Date.current)
                 find_button(text: '検索する').click
               end
-
-              it '指定範囲の記事が表示される' do
+      
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                 expect(page).to have_content user_article_2.title
+              end
+              it '指定範囲の記事サブタイトルが表示される' do
+                expect(page).to have_content article.sub_title
                 expect(page).to have_content user_article_2.sub_title
+              end
+              it '指定範囲の記事投稿日時が表示される' do
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
@@ -1418,16 +1993,26 @@ RSpec.describe 'Articles', type: :system do
                 find('#input-finish').set('01/02/2022')
                 find_button(text: '検索する').click
               end
-
-              it '指定範囲の記事が表示される' do
+      
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content user_article_2.title
+              end
+      
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content user_article_2.sub_title
+              end
+      
+              it '指定範囲の記事投稿日時が表示される' do
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
-
-              it '指定範囲外の記事は表示されない' do
+      
+              it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
+              end
+              it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
+              end
+              it '指定範囲外の記事投稿日時は表示されない' do
                 expect(page).not_to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
@@ -1437,16 +2022,26 @@ RSpec.describe 'Articles', type: :system do
                 find('#input-finish').set('01/01/2022')
                 find_button(text: '検索する').click
               end
-
-              it '指定範囲の記事が表示される' do
+      
+              it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content user_article_2.title
+              end
+      
+              it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content user_article_2.sub_title
+              end
+      
+              it '指定範囲の記事投稿日時が表示される' do
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
-
-              it '指定範囲外の記事は表示されない' do
+      
+              it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
+              end
+              it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
+              end
+              it '指定範囲外の記事投稿日時は表示されない' do
                 expect(page).not_to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
@@ -1461,27 +2056,32 @@ RSpec.describe 'Articles', type: :system do
 
               it '投稿なしと表示される' do
                 expect(page).to have_content '投稿なし'
-                expect(page).not_to have_content article.title
-                expect(page).not_to have_content user_article_2.title
-              end
-
-              it '記事は表示されない' do
-                expect(page).not_to have_content article.title
-                expect(page).not_to have_content user_article_2.title
               end
 
               it 'リセットボタンが表示される' do
                 expect(page).to have_button('リセット')
               end
 
-              it 'リセットボタン押下で記事一覧が再表示される' do
-                find_button(text: 'リセット').click
-                expect(page).to have_content article.title
-                expect(page).to have_content article.sub_title
-                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
-                expect(page).to have_content user_article_2.title
-                expect(page).to have_content user_article_2.sub_title
-                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              context 'リセットボタン押下' do
+                before do
+                  find_button(text: 'リセット').click
+                end
+                context '記事一覧が再表示され' do
+                  it '記事タイトルが表示される' do
+                    expect(page).to have_content article.title
+                    expect(page).to have_content user_article_2.title
+                  end
+      
+                  it '記事サブタイトルが表示される' do
+                    expect(page).to have_content article.sub_title
+                    expect(page).to have_content user_article_2.sub_title
+                  end
+      
+                  it '記事投稿日時が表示される' do
+                    expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+                    expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+                  end
+                end
               end
             end
           end
@@ -1492,16 +2092,28 @@ RSpec.describe 'Articles', type: :system do
               find('#input-finish').set(Date.current)
               find_button(text: '検索する').click
             end
-
-            it '指定範囲の記事が表示される' do
+      
+            it '指定範囲の記事タイトルが表示される' do
               expect(page).to have_content article.title
+            end
+      
+            it '指定範囲の記事サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
+            end
+      
+            it '指定範囲の記事投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
-
-            it '指定範囲外の記事は表示されない' do
+      
+            it '指定範囲外の記事タイトルは表示されない' do
               expect(page).not_to have_content user_article_2.title
+            end
+      
+            it '指定範囲外の記事サブタイトルは表示されない' do
               expect(page).not_to have_content user_article_2.sub_title
+            end
+      
+            it '指定範囲外の記事投稿日時は表示されない' do
               expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -1,100 +1,1618 @@
 require 'rails_helper'
 
 RSpec.describe 'Articles', type: :system do
-  let(:user_a) { create(:user, :a, confirmed_at: Date.today) }
-  let(:user_b) { create(:user, :b, confirmed_at: Date.today) }
-  let(:article) { create(:article, user: user_a) }
+  let(:user) { create(:user, confirmed_at: Date.today) }
+  let(:user_1) { create(:user, :a, confirmed_at: Date.today) }
+  let(:user_2) { create(:user, :b, confirmed_at: Date.today) }
+  let(:article) { Article.create(title: 'RSpec', sub_title: 'system', content: 'test', user: user) }
+  let(:article_1) { Article.create(title: 'RSpec', sub_title: 'system', content: 'test', user: user_1) }
+  let(:article_2) { create(:article, user: user_2) }
+  let(:article_30) { create_list(:article, 30, user: user) }
+  let(:article_148) { create_list(:article, 148, user: user) }
 
-  before do
-    sign_in(user_a)
+  before(:each) do
+    sign_in(user)
     article
   end
 
-  describe 'redirect to #X' do
-    context 'X = index || dashboards' do
-      context 'index' do
-        it 'success' do
+  describe '記事一覧画面' do # index
+    before(:each) do
+      article_2.update(created_at: Time.current + 1.minute)
+      visit users_articles_path(order: 'DESC')
+    end
+
+    it '現在のパスが記事一覧画面のパスである' do
+      expect(page).to have_current_path users_articles_path, ignore_query: true
+    end
+
+    describe '表示テスト' do
+      it '画面の見出しに記事一覧が表示される' do
+        expect(page).to have_selector('h1', text: '記事一覧')
+      end
+
+      it '正しいテーブルヘッダーが表示されていること' do
+        expect(page).to have_selector('th', text: 'タイトル')
+        expect(page).to have_selector('th', text: 'サブタイトル')
+        expect(page).to have_selector('th', text: '投稿者')
+        expect(page).to have_selector('th', text: '投稿日時')
+      end
+
+      it '全ての記事が一覧表示される' do
+        # 確認すべき内容を配列でまとめて、eachで回す
+        [article, article_2].each do |article|
+          expect(page).to have_content article.title
+          expect(page).to have_content article.sub_title
+          expect(page).to have_content article.user.name
+          expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+        end
+      end
+
+      context '３点リーダー' do
+        it '全ての記事に３点リーダーが表示されている' do
+          expect(page.all('button', text: '︙').count).to eq 2 # テスト記事は2件
+        end
+
+        context 'ログインユーザーの投稿記事' do
+          context '３点リーダー押下' do
+            before(:each) do
+              page.all(:button, '︙')[1].click # 一覧の2つ目[1]がログインユーザー（user）の記事
+            end
+
+            it '閲覧・編集・削除ボタンが表示される' do
+              expect(page).to have_content('閲覧')
+              expect(page).to have_content('編集')
+              expect(page).to have_content('削除')
+            end
+          end
+        end
+
+        context 'ログインユーザー以外の記事' do
+          before '３点リーダー押下' do
+            page.all(:button, '︙')[0].click
+            # find_button( '︙', match: :first).click
+            # click_button '︙', match: :first もOK
+            # find('button', text: '︙', match: :first).click もOK
+          end
+
+          it '閲覧ボタンのみ表示される' do
+            expect(page).to have_content('閲覧')
+            expect(page).not_to have_content('編集')
+            expect(page).not_to have_content('削除')
+          end
+        end
+      end
+
+      context 'ページネーション' do
+        before(:each) do
+          article_30
+          visit current_path
+        end
+
+        it 'ページ割で表示される' do
+          page.execute_script('window.scroll(0, 1000)') # ページ割部分まで下へスクロール
+          expect(page).to have_link('1', class: 'page-link')
+          expect(page).to have_link('2', class: 'page-link')
+          expect(page).to have_link('›', class: 'page-link')
+          expect(page).to have_link('»', class: 'page-link')
+        end
+      end
+
+      context '並べ替えボタン' do
+        it '表示されている' do
+          expect(page).to have_button('並べ替え')
+        end
+
+        context '並べ替えボタン押下' do
+          it 'モーダルが表示される' do
+            find_button(text: '並べ替え').click
+            expect(page).to have_css('.modal.fade.show')
+            expect(page).to have_css('.modal-title', text: '並べ替え')
+            expect(page).to have_content '投稿日時'
+            expect(page).to have_select('sort-select')
+            find_field('sort-select').click
+            expect(page).to have_select('sort-select', selected: '新しい順')
+            expect(page).to have_select('sort-select', text: '古い順')
+            expect(page).to have_button '並べ替える'
+            expect(page).to have_button '戻る'
+          end
+        end
+      end
+
+      context '絞り込み検索ボタン' do
+        it '表示されている' do
+          expect(page).to have_button('絞り込み検索')
+          find_button(text: '絞り込み検索').click
+        end
+
+        context '絞り込み検索ボタン押下' do
+          it 'モーダルが表示される' do
+            find_button(text: '絞り込み検索').click
+            expect(page).to have_css('.modal.fade.show')
+            expect(page).to have_css('.modal-title', text: '絞り込み検索')
+            expect(page).to have_content '投稿者'
+            expect(page).to have_selector('input#input-author')
+            expect(page).to have_content 'タイトル'
+            expect(page).to have_selector('input#input-title')
+            expect(page).to have_content 'サブタイトル'
+            expect(page).to have_selector('input#input-subtitle')
+            expect(page).to have_content '本文'
+            expect(page).to have_selector('input#input-content')
+            expect(page).to have_content '投稿日時'
+            expect(page).to have_selector('input#input-start[type="date"]')
+            expect(page).to have_selector('input#input-finish[type="date"]')
+            expect(page).to have_button '検索する'
+            expect(page).to have_button '戻る'
+          end
+        end
+      end
+    end
+
+    describe '遷移テスト' do
+      context 'ログインユーザーの投稿記事' do
+        context 'タイトルを押下' do
+          before(:each) do
+            find('#article-title', text: article.title).click
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article), ignore_query: true
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.content
+          end
+
+          it '編集・削除ボタンが表示される' do
+            expect(page).to have_content('編集')
+            expect(page).to have_content('削除')
+          end
+        end
+
+        context 'サブタイトルを押下' do
+          before(:each) do
+            find('#article-subtitle', text: article.sub_title).click
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article), ignore_query: true
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.content
+          end
+
+          it '編集・削除ボタンが表示される' do
+            expect(page).to have_content('編集')
+            expect(page).to have_content('削除')
+          end
+        end
+
+        context '投稿日時を押下' do
+          before(:each) do
+            find('#article-createdat', text: article.created_at.strftime('%Y/%m/%d %H:%M')).click
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article), ignore_query: true
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.content
+          end
+
+          it '編集・削除ボタンが表示される' do
+            expect(page).to have_content('編集')
+            expect(page).to have_content('削除')
+          end
+        end
+      end
+
+      context 'ログインユーザー以外の記事' do
+        context 'タイトルを押下' do
+          before(:each) do
+            find('#article-title', text: article_2.title).click
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article_2), ignore_query: true
+            expect(page).to have_content article_2.title
+            expect(page).to have_content article_2.sub_title
+            expect(page).to have_content article_2.content
+            expect(page).to have_content user_2.name
+          end
+
+          it '編集・削除ボタンが表示されない' do
+            expect(page).not_to have_content('編集')
+            expect(page).not_to have_content('削除')
+          end
+        end
+
+        context 'サブタイトルを押下' do
+          before(:each) do
+            find('#article-subtitle', text: article_2.sub_title).click
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article_2), ignore_query: true
+            expect(page).to have_content article_2.title
+            expect(page).to have_content article_2.sub_title
+            expect(page).to have_content article_2.content
+            expect(page).to have_content user_2.name
+          end
+
+          it '編集・削除ボタンが表示されない' do
+            expect(page).not_to have_content('編集')
+            expect(page).not_to have_content('削除')
+          end
+        end
+
+        context '投稿日時を押下' do
+          before(:each) do
+            find('#article-createdat', text: article_2.created_at.strftime('%Y/%m/%d %H:%M')).click
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article_2), ignore_query: true
+            expect(page).to have_content article_2.title
+            expect(page).to have_content article_2.sub_title
+            expect(page).to have_content article_2.content
+            expect(page).to have_content user_2.name
+          end
+
+          it '編集・削除ボタンが表示されない' do
+            expect(page).not_to have_content('編集')
+            expect(page).not_to have_content('削除')
+          end
+        end
+      end
+
+      context 'ログインユーザーの記事３点リーダー' do # 不安定なエラー発生する。解決案は, wait: 10 か、sleep 1
+        before(:each) do
+          page.all('.btn', text: '︙')[1].click # 2番目を押下
+          # click_button '︙', match: :first 1番目を押下、この記述だと２番目以降を押下指定する実装不可
+        end
+
+        context '閲覧ボタン押下' do
+          before(:each) do
+            # click_link '閲覧'
+            # find('a.nav-link', text: '閲覧').click
+            find_link('閲覧').click
+            # sleep 1 # ないと時々エラー
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article), ignore_query: true
+            expect(page).to have_content(article.title)
+            expect(page).to have_content(article.sub_title)
+            expect(page).to have_content(article.content, wait: 10)
+          end
+
+          it '編集・削除ボタンが表示される' do
+            expect(page).to have_content('編集', wait: 10)
+            expect(page).to have_content('削除')
+          end
+        end
+
+        context '編集ボタン押下' do
+          before(:each) do
+            click_link '編集'
+          end
+
+          it '編集ボタン押下で記事編集画面へ遷移する' do
+            expect(page).to have_current_path edit_users_article_path(article), ignore_query: true
+            expect(page).to have_field('article_title', with: article.title)
+            expect(page).to have_field('article_sub_title', with: article.sub_title)
+            expect(page).to have_field('article_content', with: article.content)
+          end
+        end
+      end
+
+      context 'ログインユーザー以外の記事の３点リーダー、閲覧ボタン押下' do
+        before(:each) do
+          page.all(:button, '︙')[0].click
+          # click_button '︙', match: :first #, visible: false
+          click_link '閲覧'
+          # find_link('閲覧', wait: 10).click
+          # sleep 1 これよりも , have_content オプションで wait: 10 が良いらしい
+        end
+
+        it '記事詳細画面へ遷移する' do
+          sleep 1
+          expect(page).to have_current_path users_article_path(article_2), ignore_query: true
+          expect(page).to have_content article_2.title
+          expect(page).to have_content article_2.sub_title
+          expect(page).to have_content article_2.content
+          expect(page).to have_content user_2.name
+        end
+
+        it '編集・削除ボタンが表示されない' do
+          expect(page).not_to have_content('編集')
+          expect(page).not_to have_content('削除')
+        end
+      end
+
+      describe 'ページネーション' do
+        # let(article_148) { create_list(:article, 148, title: "paginate_#{i}", sub_title: "paginate_sub_#{i}", content: "paginate_content_#{i}") }
+
+        before(:each) do
+          article_148
+          visit current_path
+          page.execute_script('window.scroll(0, 1000)')
+        end
+
+        it '1を押下で、1ページ目へ遷移する' do
+          find('.page-link', text: '2').click
+          # sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          # wait_for_ajax_without_jquery
+          find('.page-link', text: '1').click
+          sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          background_color = find_link('1').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_content 'paginate_120'
+        end
+
+        it '3を押下で、3ページ目へ遷移する' do
+          find('.page-link', text: '3').click
+          sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          background_color = find('.page-link', text: '3').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_content 'paginate_60'
+          # expect(page).to have_selector('a', text: '3', class: 'page-link')
+        end
+
+        it '5を押下で、5ページ目へ遷移する' do
+          find('.page-link', text: '5').click
+          sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          background_color = find_link('5').native.css_value('background-color')
+
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_content 'paginate_0'
+          # sleep 2
+          # expect(page).to have_selector('a', text: '5', class: 'page-link')
+        end
+
+        it '›を押下で、次のページへ遷移する' do
+          find('.page-link', text: '›').click
+          sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          background_color = find_link('2').native.css_value('background-color')
+
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_content 'paginate_90'
+          # expect(page).to have_selector('a', text: '2', class: 'page-link')
+        end
+
+        it '»を押下で、最終ページへ遷移する' do
+          find('.page-link', text: '»').click
+          sleep 2
+          page.execute_script('window.scroll(0, 1000)')
+          background_color = find_link('5').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_selector('a', text: '5', class: 'page-link')
+          # expect(page).to have_content 'paginate_0'
+          expect(page).not_to have_selector('a', text: '»', class: 'page-link')
+        end
+
+        it '‹を押下で、前のページへ遷移する' do
+          find('.page-link', text: '»').click
+          # sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          # wait_for_ajax_without_jquery
+          find('.page-link', text: '‹').click
+          sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          background_color = find_link('4').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_content 'paginate_30'
+          # expect(page).to have_selector('a', text: '4', class: 'page-link')
+        end
+
+        it '«を押下で、最初のページへ遷移する' do
+          find('.page-link', text: '»').click
+          sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          find('.page-link', text: '«').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          background_color = find_link('1').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_content 'paginate_120'
+          expect(page).not_to have_selector('.page-link', text: '«', class: 'page-link')
+        end
+      end
+    end
+
+    describe '機能テスト' do
+      it '３点リーダーから記事の削除ができる' do
+        article_first = Article.first.id
+        page.all('.btn', text: '︙')[1].click
+        # click_link '削除'
+        find_link('削除').click
+        expect {
+          expect(page.accept_confirm).to eq '選択した記事を削除します。' # accept_confirm はデフォルトで OK 押下する
+          expect(page).to have_content('記事を削除しました。', wait: 10)
+        }.to change(user.articles, :count).by(-1)
+        expect(page).not_to have_content article.title
+        expect(page).not_to have_content article.sub_title
+        expect(page).not_to have_content article.user.name
+        expect(Article).not_to exist(article_first) # DBに無い
+      end
+
+      context '並べ替えボタン' do
+        before(:each) do
+          article_2.update(created_at: Time.current)
+          article_30
+          visit current_path
+        end
+
+        context '新しい順を選択' do
+          it '降順になる' do
+            find_button(text: '並べ替え').click
+            # find('.form-select').click
+            find('.form-select', text: '新しい順').click
+            find_button(text: '並べ替える').click
+            # first_article_title = find('#article-title', match: :first).text
+            expect(find('#article-title', match: :first).text).to eq Article.last.title
+          end
+        end
+
+        context '古い順を選択' do
+          it '昇順になる' do
+            find_button(text: '並べ替え').click
+            # find('.form-select').click
+            find('.form-select option[value="ASC"]').click
+            find_button(text: '並べ替える').click
+            # sleep 3
+            expect(find('#article-title', match: :first).text).to eq Article.first.title
+          end
+        end
+      end
+
+      context '絞り込み検索ボタン' do
+        before(:each) do
+          find_button(text: '絞り込み検索').click
+        end
+
+        context '投稿者名を入力' do
+          context '条件を満たすデータが存在する場合' do
+            it '完全一致する記事を返す' do
+              fill_in 'input-author', with: '山田太郎'
+              find_button(text: '検索する').click
+              expect(page).to have_content article.title
+              expect(page).to have_content article.sub_title
+              expect(page).to have_content article.user.name
+            end
+
+            it '前方一致する記事を返す' do
+              fill_in 'input-author', with: '山'
+              find_button(text: '検索する').click
+              expect(page).to have_content article.title
+              expect(page).to have_content article.sub_title
+              expect(page).to have_content article.user.name
+            end
+
+            it '中央一致する記事を返す' do
+              fill_in 'input-author', with: '田太'
+              find_button(text: '検索する').click
+              expect(page).to have_content article.title
+              expect(page).to have_content article.sub_title
+              expect(page).to have_content article.user.name
+            end
+
+            it '後方一致する記事を返す' do
+              fill_in 'input-author', with: '郎'
+              find_button(text: '検索する').click
+              expect(page).to have_content article.title
+              expect(page).to have_content article.sub_title
+              expect(page).to have_content article.user.name
+            end
+          end
+
+          context '条件を満たすデータが存在しない場合' do
+            it '投稿なしと表示される' do
+              fill_in 'input-author', with: '存在しない名前'
+              find_button(text: '検索する').click
+              expect(page).to have_content '投稿なし'
+              expect(page).not_to have_content article.title
+            end
+          end
+        end
+
+        context 'タイトルを入力' do
+          it '完全一致する記事を返す' do
+            fill_in 'input-title', with: 'RSpec'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '前方一致する記事を返す' do
+            fill_in 'input-title', with: 'RSp'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '中央一致する記事を返す' do
+            fill_in 'input-title', with: 'Spe'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '後方一致する記事を返す' do
+            fill_in 'input-title', with: 'pec'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+        end
+
+        context 'サブタイトルを入力' do
+          it '完全一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'system'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '前方一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'sys'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '中央一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'ste'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '後方一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'tem'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+        end
+
+        context '本文' do
+          it '完全一致する記事を返す' do
+            fill_in 'input-content', with: 'test'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '完全一致する記事を返す' do
+            fill_in 'input-content', with: 'tes'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '完全一致する記事を返す' do
+            fill_in 'input-content', with: 'es'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+
+          it '完全一致する記事を返す' do
+            fill_in 'input-content', with: 'est'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+            expect(page).to have_content article.user.name
+          end
+        end
+
+        context '投稿日時で絞り込む' do
+          before(:each) do
+            article_2.update(created_at: '2022-01-01')
+            visit current_path
+            find_button(text: '絞り込み検索').click
+          end
+
+          context '指定開始日' do
+            context 'テスト当日に指定した場合' do
+              before(:each) do
+                find('#input-start').set(Date.current)
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+              end
+
+              it '指定範囲外の記事は表示されない' do
+                expect(page).not_to have_content article_2.title
+                expect(page).not_to have_content article_2.sub_title
+                expect(page).not_to have_content article_2.user.name
+              end
+            end
+
+            context '2022-01-02に指定した場合（境界値・翌日）' do
+              before(:each) do
+                find('#input-start').set('02/01/2022')
+                find_button(text: '検索する').click
+              end
+
+              it 'aritcle_2(created_at:2022-01-01)の記事が表示されない' do
+                expect(page).not_to have_content article_2.title
+                expect(page).not_to have_content article_2.sub_title
+                expect(page).not_to have_content article_2.user.name
+              end
+
+              it '指定開始日からテスト当日までの記事が表示される' do
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+              end
+            end
+
+            context '2022-01-01に指定した場合' do
+              it '指定開始日からテスト当日までの記事が表示される' do
+                find('#input-start').set('01/01/2022')
+                find_button(text: '検索する').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+            end
+
+            context '2021-12-31に指定した場合（境界値・前日）' do
+              it '指定開始日からテスト当日までの記事が表示される' do
+                find('#input-start').set('31/12/2021')
+                find_button(text: '検索する').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+            end
+
+            context '指定範囲に記事が存在しない場合' do
+              before(:each) do
+                article.update(created_at: '2022-01-01')
+                visit current_path
+                find_button(text: '絞り込み検索').click
+                find('#input-start').set(Date.current)
+                find_button(text: '検索する').click
+              end
+
+              it '投稿なしと表示される' do
+                expect(page).to have_content '投稿なし'
+              end
+
+              it '記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article_2.title
+              end
+
+              it 'リセットボタンが表示される' do
+                expect(page).to have_button('リセット')
+              end
+
+              it 'リセットボタン押下で記事一覧が再表示される' do
+                find_button(text: 'リセット').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+            end
+          end
+
+          context '指定終了日' do
+            context 'テスト当日に指定した場合' do
+              before(:each) do
+                find('#input-finish').set(Date.current)
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+            end
+
+            context '2022-01-02に指定した場合（境界値・翌日）' do
+              before(:each) do
+                find('#input-finish').set('01/02/2022')
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+
+              it '指定範囲外の記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article.sub_title
+                expect(page).not_to have_content article.user.name
+              end
+            end
+
+            context '2022-01-01に指定した場合（当日テスト）' do
+              before(:each) do
+                find('#input-finish').set('01/01/2022')
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+
+              it '指定範囲外の記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article.sub_title
+                expect(page).not_to have_content article.user.name
+              end
+            end
+
+            context '2021-012-31に指定した場合（境界値・前日）' do
+              before(:each) do
+                visit current_path
+                find_button(text: '絞り込み検索').click
+                find('#input-finish').set('31/12/2021')
+                find_button(text: '検索する').click
+              end
+
+              it '投稿なしと表示される' do
+                expect(page).to have_content '投稿なし'
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article_2.title
+              end
+
+              it '記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article_2.title
+              end
+
+              it 'リセットボタンが表示される' do
+                expect(page).to have_button('リセット')
+              end
+
+              it 'リセットボタン押下で記事一覧が再表示される' do
+                find_button(text: 'リセット').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.user.name
+                expect(page).to have_content article_2.title
+                expect(page).to have_content article_2.sub_title
+                expect(page).to have_content article_2.user.name
+              end
+            end
+          end
+
+          context '指定開始日・終了日、両方を指定' do
+            before(:each) do
+              find('#input-start').set('01/02/2022')
+              find('#input-finish').set(Date.current)
+              find_button(text: '検索する').click
+            end
+
+            it '指定範囲の記事が表示される' do
+              expect(page).to have_content article.title
+              expect(page).to have_content article.sub_title
+              expect(page).to have_content article.user.name
+            end
+
+            it '指定範囲外の記事は表示されない' do
+              expect(page).not_to have_content article_2.title
+              expect(page).not_to have_content article_2.sub_title
+              expect(page).not_to have_content article_2.user.name
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '投稿した記事一覧画面' do # dashboard
+    before(:each) do
+      article_2.update(created_at: Time.current + 1.minute)
+      visit users_dash_boards_path
+    end
+
+    it '現在のパスが記事一覧画面のパスである' do
+      expect(page).to have_current_path users_dash_boards_path, ignore_query: true
+    end
+
+    describe '表示テスト' do
+      it '画面の見出しに投稿した記事一覧が表示される' do
+        expect(page).to have_selector('h1', text: '投稿した記事一覧')
+      end
+
+      it '正しいテーブルヘッダーが表示されていること' do
+        expect(page).to have_selector('th', text: 'タイトル')
+        expect(page).to have_selector('th', text: 'サブタイトル')
+        expect(page).to have_selector('th', text: '投稿日時')
+      end
+
+      it 'ログインユーザーが投稿した記事のみ、一覧表示される' do
+        expect(page).to have_content article.title
+        expect(page).to have_content article.sub_title
+        expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+      end
+
+      it 'ログインユーザー以外の記事は表示されない' do
+        expect(page).not_to have_content article_2.title
+        expect(page).not_to have_content article_2.sub_title
+      end
+
+      context '３点リーダー' do
+        it '全ての記事に３点リーダーが表示されている' do
+          expect(page.all('button', text: '︙').count).to eq 1
+        end
+
+        context '３点リーダー押下' do
+          before(:each) do
+            page.all(:button, '︙')[0].click
+          end
+
+          it '閲覧・編集・削除ボタンが表示される' do
+            expect(page).to have_content('閲覧')
+            expect(page).to have_content('編集')
+            expect(page).to have_content('削除')
+          end
+        end
+      end
+
+      context 'ページネーション' do
+        before(:each) do
+          article_30
+          visit current_path
+        end
+
+        it '最下部にページ割で表示される' do
+          page.execute_script('window.scroll(0, 1000)') # ページ割部分まで下へスクロール
+          expect(page).to have_selector '.pagination' # 不要なテストかも
+          expect(page).to have_selector('.article-paginate') # 不要なテストかも
+          expect(page).to have_link('1', class: 'page-link')
+          expect(page).to have_link('2', class: 'page-link')
+          expect(page).to have_link('›', class: 'page-link')
+          expect(page).to have_link('»', class: 'page-link')
+        end
+      end
+
+      context '並べ替えボタン' do
+        it '表示されている' do
+          expect(page).to have_button('並べ替え')
+        end
+
+        context '並べ替えボタン押下' do
+          it 'モーダルが表示される' do
+            find_button(text: '並べ替え').click
+            expect(page).to have_css('.modal.fade.show')
+            expect(page).to have_css('.modal-title', text: '並べ替え')
+            expect(page).to have_content '投稿日時'
+            expect(page).to have_select('sort-select')
+            find_field('sort-select').click
+            expect(page).to have_select('sort-select', selected: '新しい順')
+            expect(page).to have_select('sort-select', text: '古い順')
+            expect(page).to have_button '並べ替える'
+            expect(page).to have_button '戻る'
+          end
+        end
+      end
+
+      context '絞り込み検索ボタン' do
+        it '表示されている' do
+          expect(page).to have_button('絞り込み検索')
+        end
+
+        context '絞り込み検索ボタン押下' do
+          it 'モーダルが表示される' do
+            find_button(text: '絞り込み検索').click
+            expect(page).to have_css('.modal.fade.show')
+            expect(page).to have_css('.modal-title', text: '絞り込み検索')
+            expect(page).to have_content 'タイトル'
+            expect(page).to have_selector('input#input-title')
+            expect(page).to have_content 'サブタイトル'
+            expect(page).to have_selector('input#input-subtitle')
+            expect(page).to have_content '本文'
+            expect(page).to have_selector('input#input-content')
+            expect(page).to have_content '投稿日時'
+            expect(page).to have_selector('input#input-start[type="date"]')
+            expect(page).to have_selector('input#input-finish[type="date"]')
+            expect(page).to have_button '検索する'
+            expect(page).to have_button '戻る'
+          end
+        end
+      end
+    end
+
+    describe '遷移テスト' do
+      context '記事のタイトルを押下' do
+        before(:each) do
+          find('#article-title', text: article.title).click
+        end
+
+        it '記事詳細画面へ遷移する' do
+          expect(page).to have_current_path users_article_path(article), ignore_query: true
+          expect(page).to have_content article.title
+          expect(page).to have_content article.sub_title
+          expect(page).to have_content article.content
+        end
+
+        it '編集・削除ボタンが表示される' do
+          expect(page).to have_content('編集')
+          expect(page).to have_content('削除')
+        end
+      end
+
+      context '記事のサブタイトルを押下' do
+        before(:each) do
+          find('#article-subtitle', text: article.sub_title).click
+        end
+
+        it '記事詳細画面へ遷移する' do
+          expect(page).to have_current_path users_article_path(article), ignore_query: true
+          expect(page).to have_content article.title
+          expect(page).to have_content article.sub_title
+          expect(page).to have_content article.content
+        end
+
+        it '編集・削除ボタンが表示される' do
+          expect(page).to have_content('編集')
+          expect(page).to have_content('削除')
+        end
+      end
+
+      context '記事の投稿日時を押下' do
+        before(:each) do
+          find('#article-createdat', text: article.created_at.strftime('%Y/%m/%d %H:%M')).click
+        end
+
+        it '記事詳細画面へ遷移する' do
+          expect(page).to have_current_path users_article_path(article), ignore_query: true
+          expect(page).to have_content article.title
+          expect(page).to have_content article.sub_title
+          expect(page).to have_content article.content
+        end
+
+        it '編集・削除ボタンが表示される' do
+          expect(page).to have_content('編集')
+          expect(page).to have_content('削除')
+        end
+      end
+
+      context '３点リーダー' do
+        before(:each) do
+          page.all('.btn', text: '︙')[0].click
+        end
+
+        context '閲覧ボタン押下' do
+          before(:each) do
+            find_link('閲覧').click
+            # sleep 1 # ないと時々エラー
+          end
+
+          it '記事詳細画面へ遷移する' do
+            expect(page).to have_current_path users_article_path(article), ignore_query: true
+            expect(page).to have_content(article.title)
+            expect(page).to have_content(article.sub_title)
+            expect(page).to have_content(article.content, wait: 10)
+          end
+
+          it '編集・削除ボタンが表示される' do
+            expect(page).to have_content('編集', wait: 10)
+            expect(page).to have_content('削除')
+          end
+        end
+
+        context '編集ボタン押下' do
+          before(:each) do
+            click_link '編集'
+          end
+
+          it '編集ボタン押下で記事詳細画面へ遷移する' do
+            expect(page).to have_current_path edit_users_article_path(article), ignore_query: true
+            expect(page).to have_field('article_title', with: article.title)
+            expect(page).to have_field('article_sub_title', with: article.sub_title)
+            expect(page).to have_field('article_content', with: article.content)
+          end
+        end
+      end
+
+      describe 'ページネーション' do
+        before(:each) do
+          article
+          article_148 # 計150件
+          visit current_path
+          page.execute_script('window.scroll(0, 1000)')
+        end
+
+        it '1を押下で、1ページ目へ遷移する' do
+          find('.page-link', text: '2').click
+          page.execute_script('window.scroll(0, 1000)')
+          # sleep 1
+          # wait_for_ajax_without_jquery
+          find('.page-link', text: '1').click
+          # sleep 1
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          background_color = find_link('1').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+        end
+
+        it '3を押下で、3ページ目へ遷移する' do
+          find('.page-link', text: '3').click
+          page.execute_script('window.scroll(0, 1000)')
+          # sleep 1
+          sleep 1
+          background_color = find('.page-link', text: '3').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_selector('a', text: '3', class: 'page-link')
+        end
+
+        it '5を押下で、5ページ目へ遷移する' do
+          find('.page-link', text: '5').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          background_color = find_link('5').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # sleep 2
+          # expect(page).to have_selector('a', text: '5', class: 'page-link')
+        end
+
+        it '›を押下で、次のページへ遷移する' do
+          find('.page-link', text: '›').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          background_color = find_link('2').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_selector('a', text: '2', class: 'page-link')
+        end
+
+        it '»を押下で、最終ページへ遷移する' do
+          find('.page-link', text: '»').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          background_color = find_link('5').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_selector('a', text: '5', class: 'page-link')
+          expect(page).not_to have_selector('a', text: '»', class: 'page-link')
+        end
+
+        it '‹を押下で、前のページへ遷移する' do
+          find('.page-link', text: '»').click
+          page.execute_script('window.scroll(0, 1000)')
+          # sleep 1
+          # wait_for_ajax_without_jquery
+          find('.page-link', text: '‹').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          background_color = find_link('4').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          # expect(page).to have_selector('a', text: '4', class: 'page-link')
+        end
+
+        it '«を押下で、最初のページへ遷移する' do
+          find('.page-link', text: '»').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 1
+          find('.page-link', text: '«').click
+          page.execute_script('window.scroll(0, 1000)')
+          sleep 2
+          background_color = find('.page-link', text: '1').native.css_value('background-color')
+          expect(background_color).to eq 'rgba(13, 110, 253, 1)'
+          expect(page).not_to have_selector('.page-link', text: '«', class: 'page-link')
+        end
+      end
+    end
+
+    context '機能テスト' do
+      it '３点リーダーから記事の削除ができる' do
+        article_first = Article.first.id
+        page.all('.btn', text: '︙')[0].click # click_link '︙', match: :first は ×
+        # click_link '削除'
+        find_link('削除').click
+        expect {
+          expect(page.accept_confirm).to eq '選択した記事を削除します。'
+          expect(page).to have_content('記事を削除しました。', wait: 5)
+        }.to change(user.articles, :count).by(-1)
+        expect(page).not_to have_content article.title
+        expect(page).not_to have_content article.sub_title
+        expect(page).not_to have_content article.user.name
+        expect(Article).not_to exist(article_first)
+        # sleep 1
+      end
+
+      context '並べ替えボタン' do
+        before(:each) do
+          article_30
+          visit current_path
+        end
+
+        context '新しい順を選択' do
+          it '降順になる' do
+            find_button(text: '並べ替え').click
+            # find('.form-select').click
+            find('.form-select', text: '新しい順').click
+            find_button(text: '並べ替える').click
+            expect(find('#article-title', match: :first).text).to eq Article.last.title
+          end
+        end
+
+        context '古い順を選択' do
+          it '昇順になる' do
+            find_button(text: '並べ替え').click
+            # find('.form-select').click
+            find('.form-select option[value="ASC"]').click
+            find_button(text: '並べ替える').click
+            # sleep 3
+            expect(find('#article-title', match: :first).text).to eq Article.first.title
+          end
+        end
+      end
+
+      context '絞り込み検索ボタン' do
+        let(:user_article_2) { create(:article, user: user) }
+
+        before(:each) do
+          user_article_2
+          article_1
+          visit current_path
+          find_button(text: '絞り込み検索').click
+        end
+
+        context 'タイトルを入力' do
+          it '完全一致する記事を返す' do
+            fill_in 'input-title', with: 'RSpec'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '前方一致する記事を返す' do
+            fill_in 'input-title', with: 'RSp'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '中央一致する記事を返す' do
+            fill_in 'input-title', with: 'Spe'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '後方一致する記事を返す' do
+            fill_in 'input-title', with: 'pec'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it 'ログインユーザー以外の記事は抽出されない' do
+            Article.first.destroy # ログインユーザーの投稿記事を削除
+            fill_in 'input-title', with: article_1.title
+            find_button(text: '検索する').click
+            expect(page).to have_content '投稿なし'
+            expect(page).not_to have_content article_1.title
+            expect(page).not_to have_content article_1.sub_title
+          end
+        end
+
+        context 'サブタイトルを入力' do
+          it '完全一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'system'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '前方一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'sys'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '中央一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'ste'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '後方一致する記事を返す' do
+            fill_in 'input-subtitle', with: 'tem'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+        end
+
+        context '本文' do
+          it '完全一致する記事を返す' do
+            fill_in 'input-content', with: 'test'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '前方一致する記事を返す' do
+            fill_in 'input-content', with: 'te'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '中央一致する記事を返す' do
+            fill_in 'input-content', with: 'es'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+
+          it '後方一致する記事を返す' do
+            fill_in 'input-content', with: 'st'
+            find_button(text: '検索する').click
+            expect(page).to have_content article.title
+            expect(page).to have_content article.sub_title
+          end
+        end
+
+        context '投稿日時で絞り込む' do
+          before(:each) do
+            user_article_2.update(created_at: '2022-01-01')
+            # sleep 1
+            # find_button(text: '絞り込み検索').click
+          end
+
+          context '指定開始日' do
+            context 'テスト当日に指定した場合' do
+              before(:each) do
+                find('#input-start').set(Date.current)
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+              end
+
+              it '指定範囲外の記事は表示されない' do
+                expect(page).not_to have_content user_article_2.title
+                expect(page).not_to have_content user_article_2.sub_title
+                expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+
+            context '2022-01-02に指定した場合（境界値・翌日）' do
+              before(:each) do
+                find('#input-start').set('02/01/2022')
+                find_button(text: '検索する').click
+              end
+
+              it '2022-01-01投稿の記事は表示されない' do
+                expect(page).not_to have_content user_article_2.title
+                expect(page).not_to have_content user_article_2.sub_title
+                expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+              end
+            end
+
+            context '2022-01-01に指定した場合（当日テスト）' do
+              it '指定日範囲の記事が表示される' do
+                find('#input-start').set('01/01/2022')
+                find_button(text: '検索する').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+
+            context '2021-12-31に指定した場合（境界値・前日）' do
+              it '指定日範囲の記事が表示される' do
+                find('#input-start').set('31/12/2021')
+                find_button(text: '検索する').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+
+            context '指定範囲に記事が存在しない場合' do
+              before(:each) do
+                article.update(created_at: '2022-01-01')
+                visit current_path
+                find_button(text: '絞り込み検索').click
+                find('#input-start').set(Date.current)
+                find_button(text: '検索する').click
+              end
+
+              it '投稿なしと表示される' do
+                expect(page).to have_content '投稿なし'
+              end
+
+              it '記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content user_article_2.title
+              end
+
+              it 'リセットボタンが表示される' do
+                expect(page).to have_button('リセット')
+              end
+
+              it 'リセットボタン押下で記事一覧が再表示される' do
+                find_button(text: 'リセット').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+          end
+
+          context '指定終了日' do
+            context 'テスト当日に指定した場合' do
+              before(:each) do
+                find('#input-finish').set(Date.current)
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+
+            context '2022-01-02に指定した場合（境界値・翌日）' do
+              before(:each) do
+                find('#input-finish').set('01/02/2022')
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+
+              it '指定範囲外の記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article.sub_title
+                expect(page).not_to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+
+            context '2022-01-01に指定した場合（当日テスト）' do
+              before(:each) do
+                find('#input-finish').set('01/01/2022')
+                find_button(text: '検索する').click
+              end
+
+              it '指定範囲の記事が表示される' do
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+
+              it '指定範囲外の記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content article.sub_title
+                expect(page).not_to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+
+            context '2021-012-31に指定した場合（境界値・前日）' do
+              before(:each) do
+                visit current_path
+                find_button(text: '絞り込み検索').click
+                find('#input-finish').set('31/12/2021')
+                find_button(text: '検索する').click
+              end
+
+              it '投稿なしと表示される' do
+                expect(page).to have_content '投稿なし'
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content user_article_2.title
+              end
+
+              it '記事は表示されない' do
+                expect(page).not_to have_content article.title
+                expect(page).not_to have_content user_article_2.title
+              end
+
+              it 'リセットボタンが表示される' do
+                expect(page).to have_button('リセット')
+              end
+
+              it 'リセットボタン押下で記事一覧が再表示される' do
+                find_button(text: 'リセット').click
+                expect(page).to have_content article.title
+                expect(page).to have_content article.sub_title
+                expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+                expect(page).to have_content user_article_2.title
+                expect(page).to have_content user_article_2.sub_title
+                expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+              end
+            end
+          end
+
+          context '指定開始日・終了日、両方を指定' do
+            before(:each) do
+              find('#input-start').set('01/02/2022')
+              find('#input-finish').set(Date.current)
+              find_button(text: '検索する').click
+            end
+
+            it '指定範囲の記事が表示される' do
+              expect(page).to have_content article.title
+              expect(page).to have_content article.sub_title
+              expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+            end
+
+            it '指定範囲外の記事は表示されない' do
+              expect(page).not_to have_content user_article_2.title
+              expect(page).not_to have_content user_article_2.sub_title
+              expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '画面遷移のテスト' do # redirect to #X
+    context '記事一覧画面と投稿した記事一覧画面' do # X = index || dashboards
+      after(:each) do # 記事一覧画面と投稿した記事一覧画面の共通項目テスト after(:each) doの略称
+        expect(page).to have_content 'タイトル'
+        expect(page).to have_content 'サブタイトル'
+        expect(page).to have_content '投稿日'
+
+        expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
+        expect(page).to have_content article.title
+        expect(page).to have_content article.sub_title
+
+        # expect(page).to have_button('︙')
+        click_button('︙')
+        expect(page).to have_link('閲覧')
+        expect(page).to have_link('編集')
+        expect(page).to have_link('削除')
+      end
+
+      context '記事一覧画面' do # index
+        it '成功する' do # success
           visit users_articles_path
-          expect(current_path).to eq users_articles_path
+          expect(page).to have_current_path users_articles_path, ignore_query: true
           expect(page).to have_content '記事一覧'
           expect(page).to have_content '投稿者'
           expect(page).to have_content article.user.name
         end
       end
 
-      context 'dashboards' do
-        it 'success' do
+      context '投稿した記事一覧画面' do # dashboards
+        it '成功する' do # success
           visit users_dash_boards_path
-          expect(current_path).to eq users_dash_boards_path
+          expect(page).to have_current_path users_dash_boards_path, ignore_query: true
           expect(page).to have_content '投稿した記事一覧'
-          expect(page).to_not have_content '投稿者'
-          expect(page).to_not have_content article.user.name, count: 2
+          expect(page).not_to have_content '投稿者'
+          expect(page).not_to have_content article.user.name, count: 2
         end
-      end
-
-      after do
-        expect(page).to have_content 'タイトル'
-        expect(page).to have_content 'サブタイトル'
-        expect(page).to have_content '投稿日'
-        expect(page).to have_content article.created_at.strftime('%-m/%d %-H:%M')
-        expect(page).to have_content article.title
-        expect(page).to have_content article.sub_title
       end
     end
 
-    context 'X = new || edit' do
-      context 'new' do
-        it 'success' do
+    context '記事投稿画面または記事詳細画面' do # X = new || edit
+      after(:each) do
+        expect(page).to have_content 'エディター'
+        expect(page).to have_content 'プレビュー'
+        expect(page).to have_link 'キャンセル'
+        expect(page).to have_css('.markdown-editor')
+      end
+
+      context '記事投稿画面' do # new
+        it '成功する' do # success
           visit new_users_article_path
-          expect(current_path).to eq new_users_article_path
-          expect(page).to have_content "記事投稿"
-          expect(page).to have_css('.markdown-editor', placeholder: '本文')
+          expect(page).to have_current_path new_users_article_path, ignore_query: true
+          expect(page).to have_content '記事投稿'
+          expect(page).to have_button '投稿'
+          # expect(page).to have_css('.markdown-editor', placeholder: '本文')
+          expect(page).to have_field('article_title', placeholder: 'タイトル')
+          expect(page).to have_field('article_sub_title', placeholder: 'サブタイトル')
+          expect(page).to have_field('article_content', placeholder: '本文')
+          # expect(page).to have_css('.markdown-editor')
         end
       end
 
       context 'edit' do
         it 'success' do
           visit edit_users_article_path(article)
-          expect(current_path).to eq edit_users_article_path(article)
-          expect(page).to have_content "記事編集"
-          expect(page).to have_content article.content, count: 2
+          expect(page).to have_current_path edit_users_article_path(article), ignore_query: true
+          expect(page).to have_content '記事編集'
+          expect(page).to have_button '更新'
+          expect(page).to have_field('article_title', with: article.title)
+          expect(page).to have_field('article_sub_title', with: article.sub_title)
+          expect(page).to have_field('article_content', with: article.content)
+          expect(page).to have_content article.content, count: 2 # ページ内で、article.contentの呼び出しが計2回ある
         end
-      end
-
-      after do
-        expect(page).to have_content "エディター"
-        expect(page).to have_content "プレビュー"
       end
     end
 
     context 'X = show' do
+      after(:each) do
+        expect(page).to have_current_path users_article_path(article), ignore_query: true
+        expect(page).to have_content article.title
+        expect(page).to have_content article.sub_title
+        expect(page).to have_content article.content
+      end
+
       context 'writer' do
         it 'success' do
           visit users_article_path(article)
           expect(page).to have_content '編集'
           expect(page).to have_content '削除'
-          expect(page).to_not have_content article.user.name, count: 2
+          expect(page).not_to have_content article.user.name, count: 2
         end
       end
 
       context 'non_writer' do
         it 'success' do
-          # click_link 'ログアウト'
-          find('ログアウト').click
-          sign_in(user_b)
+          find('#dropdownMenuButton').click # dropdownmenu を探してクリック
+          click_link 'ログアウト' # click_button ×
+          sign_in(user_2)
           visit users_article_path(article)
-          expect(page).to_not have_content '編集'
-          expect(page).to_not have_content '削除'
+          expect(page).not_to have_content '編集'
+          expect(page).not_to have_content '削除'
           expect(page).to have_content '投稿者'
           expect(page).to have_content article.user.name
         end
-      end
-
-      after do
-        expect(current_path).to eq users_article_path(article)
-        expect(page).to have_content article.title
-        expect(page).to have_content article.sub_title
-        expect(page).to have_content article.content
       end
     end
   end
@@ -106,7 +1624,7 @@ RSpec.describe 'Articles', type: :system do
       fill_in 'article[sub_title]', with: 'sub_title'
       fill_in 'article[content]', with: 'content'
       click_button '投稿'
-      expect(current_path).to eq users_article_path(Article.last)
+      expect(page).to have_current_path users_article_path(Article.last), ignore_query: true
       expect(page).to have_content '記事を作成しました。'
     end
 
@@ -126,10 +1644,11 @@ RSpec.describe 'Articles', type: :system do
       fill_in 'article[content]', with: 'こんてんつ'
       click_button '更新'
       article.reload
-      expect(current_path).to eq users_article_path(article)
+      expect(page).to have_current_path users_article_path(article), ignore_query: true
       expect(page).to have_content '記事を編集しました。'
       expect(page).to have_content article.title
-      expect(page).to_not have_content prev_article_title
+
+      expect(page).not_to have_content prev_article_title
     end
 
     it 'failure' do
@@ -137,7 +1656,7 @@ RSpec.describe 'Articles', type: :system do
       fill_in 'article[title]', with: nil
       click_button '更新'
       expect(page).to have_content '記事の編集に失敗しました。'
-      expect(page).to_not have_content article.title
+      expect(page).not_to have_content article.title
     end
   end
 
@@ -146,14 +1665,15 @@ RSpec.describe 'Articles', type: :system do
       it 'success' do
         visit users_dash_boards_path
         expect(page).to have_content article.title
-        page.find('.link-tr', text: article.title).click
-        expect(current_path).to eq users_article_path(article)
+        # page.find('.link-tr', text: article.title).click
+        page.first('.link-td', text: article.title).click
+        expect(page).to have_current_path users_article_path(article), ignore_query: true
         page.accept_confirm('表示中の記事を削除します。') do
-          click_link "削除"
+          click_link '削除'
         end
         expect(page).to have_content '記事を削除しました。'
-        expect(current_path).to eq users_dash_boards_path(user_a)
-        expect(page).to_not have_content article.title
+        expect(page).to have_current_path users_dash_boards_path(user), ignore_query: true
+        expect(page).not_to have_content article.title
       end
     end
 
@@ -161,53 +1681,53 @@ RSpec.describe 'Articles', type: :system do
       it 'success' do
         visit users_articles_path
         expect(page).to have_content article.title
-        page.find('.link-tr', text: article.title).click
-        expect(current_path).to eq users_article_path(article)
+        page.first('.link-td', text: article.title).click
+        expect(page).to have_current_path users_article_path(article), ignore_query: true
         page.accept_confirm('表示中の記事を削除します。') do
-          click_link "削除"
+          click_link '削除'
         end
         expect(page).to have_content '記事を削除しました。'
-        expect(current_path).to eq users_articles_path
-        expect(page).to_not have_content article.title
+        expect(page).to have_current_path users_articles_path, ignore_query: true
+        expect(page).not_to have_content article.title
       end
     end
   end
-  
-  describe 'markdown with marked.js', js: true do
-    before do
+
+  describe 'markdown with marked.js', js: true do # Marked.js によるマークダウン
+    before(:each) do
       article.content = "# This is h1.  \r\n```ruby:qiita.rb\r\nputs 'The best way to log and share programmers knowledge.'\r\n```"
       article.save
     end
-    
-    describe 'new article page' do
-      before do
+
+    describe 'new article page' do # 記事投稿画面で
+      before(:each) do
         visit new_users_article_path
         sleep 1
         @markd = find('.markdown-editor')
         @preview = find('.preview')
       end
-      
-      it 'markdown to preview' do
+
+      it 'markdown to preview' do # プレビュー画面でマークダウンが機能している
         @markd.set(article.content)
-        expect(@preview).to have_css('h1', text: 'This is h1.', wait: 1)
+        expect(@preview).to have_css('h1', text: 'This is h1.', wait: 1) # 「#」の文字列が、h1のcssになっていることを期待
       end
-      
+
       it 'drag and drop image' do
-        img = file_fixture("ruby.png")
+        img = file_fixture('ruby.png')
         @markd.drop(img)
         page.save_screenshot 'rubyロゴ画像添付.png'
         expect(@preview).to have_css('img[alt="ruby.png"]', wait: 1)
         expect(@markd.value).to start_with '<img alt="ruby.png"'
       end
-      
+
       it 'to code block' do
         @markd.set(article.content)
         page.save_screenshot 'newページのコードブロック.png'
         expect(@preview).to have_selector('.code-frame', visible: true)
         frame = @preview.find('.code-frame')
-        expect(frame).to match_style({"background-color": "rgba(54, 69, 73, 1)"})
+        expect(frame).to match_style({ "background-color": 'rgba(54, 69, 73, 1)' })
         expect(frame).to have_selector('.code-ref', visible: true)
-        expect(frame).to have_css('.code-ref', text: "qiita.rb", visible: true)
+        expect(frame).to have_css('.code-ref', text: 'qiita.rb', visible: true)
         expect(frame).to have_css('code', text: "puts 'The best way to log and share programmers knowledge.'", visible: true)
       end
     end
@@ -242,7 +1762,7 @@ RSpec.describe 'Articles', type: :system do
         wait_for_ajax
         page.accept_confirm do
           page.save_screenshot '記事詳細copy.png'
-          expect(find('.copybtn').text).to_not eq 'コードコピー'
+          expect(find('.copybtn').text).not_to eq 'コードコピー'
           expect(page).to have_css('.copybtn', text: 'コードコピー', visible: false)
           page.execute_script("$('.paste').val(navigator.clipboard.readText())")
           expect(find('.paste').value).to eq 'コピー成功'
@@ -271,4 +1791,4 @@ end
 #   dataTransfer.files.add(fakeFileInput.get(0).files[0])
 #   testEvent = new DragEvent('drop', {bubbles:true, dataTransfer: dataTransfer })
 #   $('.markdown-editor').dispatchEvent(testEvent)
-# JS      
+# JS

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe 'Articles', type: :system do
         it 'サブタイトルと表示されていること' do
           expect(page).to have_selector('th', text: 'サブタイトル')
         end
-  
+
         it '投稿者と表示されていること' do
           expect(page).to have_selector('th', text: '投稿者')
         end
-  
+
         it '投稿日時と表示されていること' do
           expect(page).to have_selector('th', text: '投稿日時')
         end
@@ -135,7 +135,7 @@ RSpec.describe 'Articles', type: :system do
         end
 
         context '並べ替えボタン押下' do
-          before do
+          before(:each) do
             find_button(text: '並べ替え').click
           end
 
@@ -147,25 +147,25 @@ RSpec.describe 'Articles', type: :system do
             it 'タイトルに並び替えが表示される' do
               expect(page).to have_css('.modal-title', text: '並べ替え')
             end
-  
+
             it '投稿日時の項目が表示される' do
               expect(page).to have_content '投稿日時'
             end
-  
+
             it '並べ替えるボタンが表示される' do
               expect(page).to have_button '並べ替える'
             end
-            
+
             it '戻るボタンが表示される' do
               expect(page).to have_button '戻る'
             end
-  
+
             it 'セレクトフォームが表示される' do
               expect(page).to have_select('sort-select')
             end
-  
+
             context 'セレクトフォームをクリック' do
-              before do
+              before(:each) do
                 find_field('sort-select').click
               end
 
@@ -187,14 +187,14 @@ RSpec.describe 'Articles', type: :system do
         end
 
         context 'ボタン押下' do
-          before do
+          before(:each) do
             find_button(text: '絞り込み検索').click
           end
 
           it 'モーダルが表示される' do
             expect(page).to have_css('.modal.fade.show')
           end
-        
+
           it 'モーダルタイトルが「絞り込み検索」と表示される' do
             expect(page).to have_css('.modal-title', text: '絞り込み検索')
           end
@@ -202,7 +202,7 @@ RSpec.describe 'Articles', type: :system do
           it '検索ボタンが表示される' do
             expect(page).to have_button '検索する'
           end
-      
+
           it '戻るボタンが表示される' do
             expect(page).to have_button '戻る'
           end
@@ -233,23 +233,23 @@ RSpec.describe 'Articles', type: :system do
             it '投稿者フィールドの表示がある' do
               expect(page).to have_selector('input#input-author')
             end
-        
+
             it 'タイトルフィールドが表示される' do
               expect(page).to have_selector('input#input-title')
             end
-        
+
             it 'サブタイトルフィールドが表示される' do
               expect(page).to have_selector('input#input-subtitle')
             end
-        
+
             it '本文フィールドが表示される' do
               expect(page).to have_selector('input#input-content')
             end
-        
+
             it '投稿開始日フィールドが表示される' do
               expect(page).to have_selector('input#input-start[type="date"]')
             end
-  
+
             it '投稿終了日フィールドが表示される' do
               expect(page).to have_selector('input#input-finish[type="date"]')
             end
@@ -464,8 +464,7 @@ RSpec.describe 'Articles', type: :system do
 
     describe '機能テスト' do
       context '３点リーダーから削除ボタン押下' do
-        before do
-          article_first = Article.first.id
+        before(:each) do
           page.all('.btn', text: '︙')[1].click
           # click_link '削除'
           find_link('削除').click
@@ -478,7 +477,7 @@ RSpec.describe 'Articles', type: :system do
           }.to change(user.articles, :count).by(-1)
         end
       end
-      
+
       context '並べ替えボタン' do
         before(:each) do
           article_2.update(created_at: Time.current)
@@ -487,26 +486,28 @@ RSpec.describe 'Articles', type: :system do
         end
 
         context '新しい順を選択' do
-          before do
+          before(:each) do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select', text: '新しい順').click
             find_button(text: '並べ替える').click
             # first_article_title = find('#article-title', match: :first).text
           end
+
           it '降順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.last.title
           end
         end
 
         context '古い順を選択' do
-          before do
+          before(:each) do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select option[value="ASC"]').click
             find_button(text: '並べ替える').click
             # sleep 3
           end
+
           it '昇順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.first.title
           end
@@ -521,7 +522,7 @@ RSpec.describe 'Articles', type: :system do
         context '投稿者名' do
           context '条件を満たすデータが存在する' do
             context '完全一致する名前を入力し検索する押下' do
-              before do
+              before(:each) do
                 fill_in 'input-author', with: '山田太郎'
                 find_button(text: '検索する').click
               end
@@ -529,18 +530,18 @@ RSpec.describe 'Articles', type: :system do
               it 'タイトルが表示される' do
                 expect(page).to have_content article.title
               end
-  
+
               it 'サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
-  
+
               it '投稿者名が表示される' do
                 expect(page).to have_content article.user.name
               end
             end
 
             context '前方一致する名前を入力し検索する押下' do
-              before do
+              before(:each) do
                 fill_in 'input-author', with: '山'
                 find_button(text: '検索する').click
               end
@@ -548,18 +549,18 @@ RSpec.describe 'Articles', type: :system do
               it 'タイトルが表示される' do
                 expect(page).to have_content article.title
               end
-  
+
               it 'サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
-  
+
               it '投稿者名が表示される' do
                 expect(page).to have_content article.user.name
               end
             end
 
             context '中央一致する名前を入力し検索する押下' do
-              before do
+              before(:each) do
                 fill_in 'input-author', with: '田太'
                 find_button(text: '検索する').click
               end
@@ -567,18 +568,18 @@ RSpec.describe 'Articles', type: :system do
               it 'タイトルが表示される' do
                 expect(page).to have_content article.title
               end
-  
+
               it 'サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
-  
+
               it '投稿者名が表示される' do
                 expect(page).to have_content article.user.name
               end
             end
 
             context '後方一致する名前を入力し検索する押下' do
-              before do
+              before(:each) do
                 fill_in 'input-author', with: '郎'
                 find_button(text: '検索する').click
               end
@@ -586,11 +587,11 @@ RSpec.describe 'Articles', type: :system do
               it 'タイトルが表示される' do
                 expect(page).to have_content article.title
               end
-  
+
               it 'サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
-  
+
               it '投稿者名が表示される' do
                 expect(page).to have_content article.user.name
               end
@@ -608,7 +609,7 @@ RSpec.describe 'Articles', type: :system do
 
         context 'タイトル' do
           context '完全一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'RSpec'
               find_button(text: '検索する').click
             end
@@ -627,7 +628,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '前方一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'RSp'
               find_button(text: '検索する').click
             end
@@ -646,7 +647,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '中央一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'Spe'
               find_button(text: '検索する').click
             end
@@ -663,9 +664,9 @@ RSpec.describe 'Articles', type: :system do
               expect(page).to have_content article.user.name
             end
           end
-          
+
           context '後方一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'pec'
               find_button(text: '検索する').click
             end
@@ -686,7 +687,7 @@ RSpec.describe 'Articles', type: :system do
 
         context 'サブタイトル' do
           context '完全一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'system'
               find_button(text: '検索する').click
             end
@@ -703,9 +704,9 @@ RSpec.describe 'Articles', type: :system do
               expect(page).to have_content article.user.name
             end
           end
-          
+
           context '前方一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'sys'
               find_button(text: '検索する').click
             end
@@ -724,7 +725,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '中央一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'ste'
               find_button(text: '検索する').click
             end
@@ -743,7 +744,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '後方一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'tem'
               find_button(text: '検索する').click
             end
@@ -764,7 +765,7 @@ RSpec.describe 'Articles', type: :system do
 
         context '本文' do
           context '完全一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'test'
               find_button(text: '検索する').click
             end
@@ -783,7 +784,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '前方一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'tes'
               find_button(text: '検索する').click
             end
@@ -800,9 +801,9 @@ RSpec.describe 'Articles', type: :system do
               expect(page).to have_content article.user.name
             end
           end
-          
+
           context '中央一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'es'
               find_button(text: '検索する').click
             end
@@ -821,7 +822,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '後方一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'est'
               find_button(text: '検索する').click
             end
@@ -911,7 +912,7 @@ RSpec.describe 'Articles', type: :system do
             end
 
             context '2022-01-01に指定して検索' do
-              before do
+              before(:each) do
                 find('#input-start').set('01/01/2022')
                 find_button(text: '検索する').click
               end
@@ -933,7 +934,7 @@ RSpec.describe 'Articles', type: :system do
             end
 
             context '2021-12-31に指定した場合（境界値・前日）' do
-              before do
+              before(:each) do
                 find('#input-start').set('31/12/2021')
                 find_button(text: '検索する').click
               end
@@ -972,7 +973,7 @@ RSpec.describe 'Articles', type: :system do
               end
 
               context 'リセットボタン押下' do
-                before do
+                before(:each) do
                   find_button(text: 'リセット').click
                 end
 
@@ -1007,10 +1008,12 @@ RSpec.describe 'Articles', type: :system do
                 expect(page).to have_content article.title
                 expect(page).to have_content article_2.title
               end
+
               it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
                 expect(page).to have_content article_2.sub_title
               end
+
               it '指定範囲の記事投稿者名が表示される' do
                 expect(page).to have_content article.user.name
                 expect(page).to have_content article_2.user.name
@@ -1038,9 +1041,11 @@ RSpec.describe 'Articles', type: :system do
               it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
               end
+
               it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
               end
+
               it '指定範囲外の記事投稿者名は表示されない' do
                 expect(page).not_to have_content article.user.name
               end
@@ -1067,9 +1072,11 @@ RSpec.describe 'Articles', type: :system do
               it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
               end
+
               it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
               end
+
               it '指定範囲外の記事投稿者名は表示されない' do
                 expect(page).not_to have_content article.user.name
               end
@@ -1092,9 +1099,10 @@ RSpec.describe 'Articles', type: :system do
               end
 
               context 'リセットボタン押下' do
-                before do
+                before(:each) do
                   find_button(text: 'リセット').click
                 end
+
                 context '記事一覧が再表示され' do
                   it '記事タイトルが表示される' do
                     expect(page).to have_content article.title
@@ -1174,7 +1182,7 @@ RSpec.describe 'Articles', type: :system do
         it 'サブタイトルと表示されていること' do
           expect(page).to have_selector('th', text: 'サブタイトル')
         end
-  
+
         it '投稿日時と表示されていること' do
           expect(page).to have_selector('th', text: '投稿日時')
         end
@@ -1183,9 +1191,11 @@ RSpec.describe 'Articles', type: :system do
       it 'ログインユーザーが投稿した記事タイトルが表示される' do
         expect(page).to have_content article.title
       end
+
       it 'ログインユーザーが投稿した記事サブタイトルが表示される' do
         expect(page).to have_content article.sub_title
       end
+
       it 'ログインユーザーが投稿した記事投稿日時が表示される' do
         expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
       end
@@ -1193,7 +1203,7 @@ RSpec.describe 'Articles', type: :system do
       it 'ログインユーザー以外の記事タイトルは表示されない' do
         expect(page).not_to have_content article_2.title
       end
-      
+
       it 'ログインユーザー以外の記事サブタイトルは表示されない' do
         expect(page).not_to have_content article_2.sub_title
       end
@@ -1247,114 +1257,112 @@ RSpec.describe 'Articles', type: :system do
       end
 
       context '並べ替えボタン押下' do
-        before do
+        before(:each) do
           find_button(text: '並べ替え').click
         end
-      
+
         it 'モーダルが表示される' do
           expect(page).to have_css('.modal.fade.show')
         end
-      
+
         context 'モーダル内' do
           it 'タイトルに並び替えが表示される' do
             expect(page).to have_css('.modal-title', text: '並べ替え')
           end
-      
+
           it '投稿日時の項目が表示される' do
             expect(page).to have_content '投稿日時'
           end
-      
+
           it '並べ替えるボタンが表示される' do
             expect(page).to have_button '並べ替える'
           end
-          
+
           it '戻るボタンが表示される' do
             expect(page).to have_button '戻る'
           end
-      
+
           it 'セレクトフォームが表示される' do
             expect(page).to have_select('sort-select')
           end
-      
+
           context 'セレクトフォームをクリック' do
-            before do
+            before(:each) do
               find_field('sort-select').click
             end
-      
+
             it '新しい順のセレクタが表示される' do
               expect(page).to have_select('sort-select', selected: '新しい順')
             end
-      
+
             it '古い順のセレクタが表示される' do
               expect(page).to have_select('sort-select', text: '古い順')
             end
           end
         end
       end
-      
+
       context '絞り込み検索ボタン　' do
         it '表示されている' do
           expect(page).to have_button('絞り込み検索')
         end
-      
+
         context 'ボタン押下' do
-          before do
+          before(:each) do
             find_button(text: '絞り込み検索').click
           end
-      
+
           it 'モーダルが表示される' do
             expect(page).to have_css('.modal.fade.show')
           end
-        
+
           it 'モーダルタイトルが「絞り込み検索」と表示される' do
             expect(page).to have_css('.modal-title', text: '絞り込み検索')
           end
-      
+
           it '検索ボタンが表示される' do
             expect(page).to have_button '検索する'
           end
-      
+
           it '戻るボタンが表示される' do
             expect(page).to have_button '戻る'
           end
-      
+
           context 'ラベル' do
-      
             it 'タイトルの表示がある' do
               expect(page).to have_content 'タイトル'
             end
-      
+
             it 'サブタイトルの表示がある' do
               expect(page).to have_content 'サブタイトル'
             end
-      
+
             it '本文の表示がある' do
               expect(page).to have_content '本文'
             end
-      
+
             it '投稿日時の表示がある' do
               expect(page).to have_content '投稿日時'
             end
           end
-      
+
           context 'フィールド' do
-        
             it 'タイトルフィールドが表示される' do
               expect(page).to have_selector('input#input-title')
             end
-        
+
             it 'サブタイトルフィールドが表示される' do
               expect(page).to have_selector('input#input-subtitle')
             end
-        
+
             it '本文フィールドが表示される' do
               expect(page).to have_selector('input#input-content')
             end
-        
+
             it '投稿開始日フィールドが表示される' do
               expect(page).to have_selector('input#input-start[type="date"]')
             end
-      
+
             it '投稿終了日フィールドが表示される' do
               expect(page).to have_selector('input#input-finish[type="date"]')
             end
@@ -1509,12 +1517,12 @@ RSpec.describe 'Articles', type: :system do
 
     describe '機能テスト' do
       context '３点リーダーから削除ボタン押下' do
-        before do
-          article_first = Article.first.id
+        before(:each) do
           page.all('.btn', text: '︙')[0].click
           # click_link '削除'
           find_link('削除').click
         end
+
         it '記事の削除ができる' do
           expect {
             expect(page.accept_confirm).to eq '選択した記事を削除します。'
@@ -1522,41 +1530,43 @@ RSpec.describe 'Articles', type: :system do
           }.to change(user.articles, :count).by(-1)
         end
       end
-      
+
       context '並べ替えボタン' do
         before(:each) do
           article_2.update(created_at: Time.current)
           article_30
           visit current_path
         end
-      
+
         context '新しい順を選択' do
-          before do
+          before(:each) do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select', text: '新しい順').click
             find_button(text: '並べ替える').click
             # first_article_title = find('#article-title', match: :first).text
           end
+
           it '降順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.last.title
           end
         end
-      
+
         context '古い順を選択' do
-          before do
+          before(:each) do
             find_button(text: '並べ替え').click
             # find('.form-select').click
             find('.form-select option[value="ASC"]').click
             find_button(text: '並べ替える').click
             # sleep 3
           end
+
           it '昇順になる' do
             expect(find('#article-title', match: :first).text).to eq Article.first.title
           end
         end
       end
-      
+
       context '絞り込み検索ボタン' do
         let(:user_article_2) { create(:article, user: user) }
 
@@ -1569,14 +1579,15 @@ RSpec.describe 'Articles', type: :system do
 
         context 'タイトル' do
           context '完全一致するタイトルを入力し検索する押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'RSpec'
               find_button(text: '検索する').click
             end
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-    
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
@@ -1587,15 +1598,15 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '前方一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'RSp'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
@@ -1606,15 +1617,15 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '中央一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'Spe'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
@@ -1625,15 +1636,15 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context '後方一致するタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-title', with: 'pec'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
@@ -1644,7 +1655,7 @@ RSpec.describe 'Articles', type: :system do
           end
 
           context 'ログインユーザー以外の記事を絞り込み検索' do
-            before do
+            before(:each) do
               Article.first.destroy # ログインユーザーの投稿記事を削除
               fill_in 'input-title', with: article_1.title
               find_button(text: '検索する').click
@@ -1662,76 +1673,76 @@ RSpec.describe 'Articles', type: :system do
 
         context 'サブタイトル' do
           context '完全一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'system'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end
-          
+
           context '前方一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'sys'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end
-      
+
           context '中央一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'ste'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end
-      
+
           context '後方一致するサブタイトルを入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-subtitle', with: 'tem'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
@@ -1740,76 +1751,76 @@ RSpec.describe 'Articles', type: :system do
 
         context '本文' do
           context '完全一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'test'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end
-      
+
           context '前方一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'tes'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end
-          
+
           context '中央一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'es'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
           end
-      
+
           context '後方一致する本文を入力して検索押下' do
-            before do
+            before(:each) do
               fill_in 'input-content', with: 'est'
               find_button(text: '検索する').click
             end
-      
+
             it 'タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it 'サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
@@ -1833,7 +1844,7 @@ RSpec.describe 'Articles', type: :system do
               it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
               end
-      
+
               it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
@@ -1845,7 +1856,7 @@ RSpec.describe 'Articles', type: :system do
               it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.title
               end
-      
+
               it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.sub_title
               end
@@ -1864,11 +1875,11 @@ RSpec.describe 'Articles', type: :system do
               it '2022-01-01投稿の記事タイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.title
               end
-      
+
               it '2022-01-01投稿の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content user_article_2.sub_title
               end
-      
+
               it '2022-01-01投稿の記事投稿日時は表示されない' do
                 expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
@@ -1876,16 +1887,18 @@ RSpec.describe 'Articles', type: :system do
               it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
               end
+
               it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
               end
+
               it '指定範囲の記事投稿日時が表示される' do
                 expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
               end
             end
 
             context '2022-01-01に指定した場合（当日テスト）' do
-              before do
+              before(:each) do
                 find('#input-start').set('01/01/2022')
                 find_button(text: '検索する').click
               end
@@ -1894,10 +1907,12 @@ RSpec.describe 'Articles', type: :system do
                 expect(page).to have_content article.title
                 expect(page).to have_content user_article_2.title
               end
+
               it '指定日範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
                 expect(page).to have_content user_article_2.sub_title
               end
+
               it '指定日範囲の記事投稿日時が表示される' do
                 expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
@@ -1905,7 +1920,7 @@ RSpec.describe 'Articles', type: :system do
             end
 
             context '2021-12-31に指定した場合（境界値・前日）' do
-              before do
+              before(:each) do
                 find('#input-start').set('31/12/2021')
                 find_button(text: '検索する').click
               end
@@ -1944,20 +1959,21 @@ RSpec.describe 'Articles', type: :system do
               end
 
               context 'リセットボタン押下' do
-                before do
+                before(:each) do
                   find_button(text: 'リセット').click
                 end
+
                 context '記事一覧が再表示され' do
                   it '記事タイトルが表示される' do
                     expect(page).to have_content article.title
                     expect(page).to have_content user_article_2.title
                   end
-      
+
                   it '記事サブタイトルが表示される' do
                     expect(page).to have_content article.sub_title
                     expect(page).to have_content user_article_2.sub_title
                   end
-      
+
                   it '記事投稿日時が表示される' do
                     expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                     expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
@@ -1973,15 +1989,17 @@ RSpec.describe 'Articles', type: :system do
                 find('#input-finish').set(Date.current)
                 find_button(text: '検索する').click
               end
-      
+
               it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content article.title
                 expect(page).to have_content user_article_2.title
               end
+
               it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content article.sub_title
                 expect(page).to have_content user_article_2.sub_title
               end
+
               it '指定範囲の記事投稿日時が表示される' do
                 expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
@@ -1993,25 +2011,27 @@ RSpec.describe 'Articles', type: :system do
                 find('#input-finish').set('01/02/2022')
                 find_button(text: '検索する').click
               end
-      
+
               it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content user_article_2.title
               end
-      
+
               it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content user_article_2.sub_title
               end
-      
+
               it '指定範囲の記事投稿日時が表示される' do
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
-      
+
               it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
               end
+
               it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
               end
+
               it '指定範囲外の記事投稿日時は表示されない' do
                 expect(page).not_to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
               end
@@ -2022,25 +2042,27 @@ RSpec.describe 'Articles', type: :system do
                 find('#input-finish').set('01/01/2022')
                 find_button(text: '検索する').click
               end
-      
+
               it '指定範囲の記事タイトルが表示される' do
                 expect(page).to have_content user_article_2.title
               end
-      
+
               it '指定範囲の記事サブタイトルが表示される' do
                 expect(page).to have_content user_article_2.sub_title
               end
-      
+
               it '指定範囲の記事投稿日時が表示される' do
                 expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
               end
-      
+
               it '指定範囲外の記事タイトルは表示されない' do
                 expect(page).not_to have_content article.title
               end
+
               it '指定範囲外の記事サブタイトルは表示されない' do
                 expect(page).not_to have_content article.sub_title
               end
+
               it '指定範囲外の記事投稿日時は表示されない' do
                 expect(page).not_to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
               end
@@ -2063,20 +2085,21 @@ RSpec.describe 'Articles', type: :system do
               end
 
               context 'リセットボタン押下' do
-                before do
+                before(:each) do
                   find_button(text: 'リセット').click
                 end
+
                 context '記事一覧が再表示され' do
                   it '記事タイトルが表示される' do
                     expect(page).to have_content article.title
                     expect(page).to have_content user_article_2.title
                   end
-      
+
                   it '記事サブタイトルが表示される' do
                     expect(page).to have_content article.sub_title
                     expect(page).to have_content user_article_2.sub_title
                   end
-      
+
                   it '記事投稿日時が表示される' do
                     expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
                     expect(page).to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
@@ -2092,27 +2115,27 @@ RSpec.describe 'Articles', type: :system do
               find('#input-finish').set(Date.current)
               find_button(text: '検索する').click
             end
-      
+
             it '指定範囲の記事タイトルが表示される' do
               expect(page).to have_content article.title
             end
-      
+
             it '指定範囲の記事サブタイトルが表示される' do
               expect(page).to have_content article.sub_title
             end
-      
+
             it '指定範囲の記事投稿日時が表示される' do
               expect(page).to have_content article.created_at.strftime('%Y/%m/%d %H:%M')
             end
-      
+
             it '指定範囲外の記事タイトルは表示されない' do
               expect(page).not_to have_content user_article_2.title
             end
-      
+
             it '指定範囲外の記事サブタイトルは表示されない' do
               expect(page).not_to have_content user_article_2.sub_title
             end
-      
+
             it '指定範囲外の記事投稿日時は表示されない' do
               expect(page).not_to have_content user_article_2.created_at.strftime('%Y/%m/%d %H:%M')
             end


### PR DESCRIPTION
**PR概要**
記事機能、システムスペックテスト実装

**実装内容**
spec/system/articles_spec.rb 1 ~ 1511 記事一覧・投稿した記事一覧画面のシステムスペックテストを実装。
テストに伴い、app/views/users/articles/shared/_articles_table.html.erbで各項目にid付与。

【記事一覧画面】　18 ~ 842

【投稿した記事一覧画面】　844 ~ 1511

・[system/articles_spec QAシート](https://docs.google.com/spreadsheets/d/16BqCFNKKG0tpCQMsiXOKIhEDXpK4KOTJ0UDsiEIvhdE/edit#gid=119836266)

**テストコマンド**
bin/docker/bundle/exec rspec spec/system/articles_spec.rb:18 # 記事一覧画面テスト
bin/docker/bundle/exec rspec spec/system/articles_spec.rb:1154 # 投稿した記事一覧画面テスト

**お伝えしたいこと**
一つのテストに10分くらいかかりPC重くなります。空き時間にテストすることお勧めします🙇‍♂️
未完成での提出のため、コメントアウト、残して欲しいです🙇‍♂️

