### PR TITLE
プロフィール一覧 > 並び替えの機能の修正

### DIFF
--- a/app/views/users/profiles/index.html.erb
+++ b/app/views/users/profiles/index.html.erb
@@ -80,11 +80,11 @@
           <div class="form-group row my-5">
             <label for="sort-select" class="col-sm-3 col-form-label"><%= Profile.human_attribute_name(:registration_date) %></label>
             <div class="col-md-9">
-              <% order = {'DESC': '新しい順', 'ASC': '古い順'} %>
-              <% params[:order] ||= 'DESC' %>
+              <% ord_select = {'DESC': '新しい順', 'ASC': '古い順'} %>
+              <% params[:ord_select] ||= 'DESC' %>
               <select id="sort-select" class="form-select" aria-label="Default select desc">
-                <option value="<%= params[:order] %>" selected><%= order.delete(:"#{params[:order]}") %></option>
-                <option value="<%= order.keys[0] %>"><%= order[order.keys[0]] %></option>
+                <option value="<%= params[:ord_select] %>" selected><%= ord_select.delete(:"#{params[:ord_select]}") %></option>
+                <option value="<%= ord_select.keys[0] %>"><%= ord_select[ord_select.keys[0]] %></option>
               </select>
             </div>
           </div>


### PR DESCRIPTION
▫️概要

一般ユーザー > プロフィール一覧 >並べ替え機能の修正
→[古い順]で検索するとデバッグ情報にorder: DESC と表示される
→[新しい順]で検索しても、同じくorder: DESC と表示される

上記のorder: DESCが表示される現象を解消

<img width="1336" alt="修正前の並び替えの画像" src="https://github.com/nishinotakay/teac-output-new/assets/111734087/e77cb078-2836-41d6-a878-bddb4cd6bdc2">

———-

◽️タスク・仕様書

https://trello.com/c/BcBFjCT9

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=1267198108

———-

◽️実装内容・手法

・profiles/index.html.erbのorder を ord_selectに修正

→ 並び替えの際に使用されているパラメーターはorder=>ではなく ord_select=>であったため。

————

▫️確認事項

・動作確認

→[新しい順] [古い順]で並び替えした際にデバッグ情報にorder に関する表示されないことの確認をお願いします。

—————

▫️補足事項

実装の経緯

・ profiles_controller.rbをbinding.pryで調べると、params[:order]が nil でした。
パラメーターがorder ハッシュ で飛んでいませんでした。

・ ターミナルで飛んでいるパラメーターを確認すると、
並び替えをクリックして飛んでいるパラメーターが、実はParameters: {"ord_select"=>""}であることを確認。

・ デバック情報で、order:DESCと表示されていた原因は、viewに<% params[:order] ||= 'DESC' %>とデフォルト値が記載されていますが、実際は並び替え機能はord_selectパラメーターが動かしているため、orderは初期値のDESCのまま更新されていなかったと思われます。