### PR TITLE
Googleでログイン機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,10 @@ gem 'dotenv-rails'
 gem 'rinku'
 gem 'draper'
 
+gem 'omniauth', '~> 2.0'
+gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
+
 group :development, :test do
   # ERD生成
   gem 'rails-erd'

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -3,31 +3,26 @@
 module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     layout 'users_auth'
-    # You should configure your model like this:
-    # devise :omniauthable, omniauth_providers: [:twitter]
 
-    # You should also create an action method in this controller like this:
-    # def twitter
-    # end
+    def google_oauth2
+      callback_for(:google)
+    end
 
-    # More info at:
-    # https://github.com/heartcombo/devise#omniauth
+    def callback_for(provider)
+      @user = User.from_omniauth(request.env["omniauth.auth"])
 
-    # GET|POST /resource/auth/twitter
-    # def passthru
-    #   super
-    # end
+      unless @user.confirmed?
+        @user.confirmed_at = Time.now
+        @user.save
+      end
 
-    # GET|POST /users/auth/twitter/callback
-    # def failure
-    #   super
-    # end
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "#{provider.capitalize}") if is_navigational_format?
+    end
 
-    # protected
+    def failure
+      redirect_to root_path
+    end
 
-    # The path used when OmniAuth fails
-    # def after_omniauth_failure_path_for(scope)
-    #   super(scope)
-    # end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,8 +46,7 @@ class User < ApplicationRecord
   def article_already_liked?(article_id)
     likes.where(article_id: article_id).exists?
   end
-
-
+  
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.name = auth.info.name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :validatable,
-    :confirmable
+    :confirmable,
+    :omniauthable, omniauth_providers: %i[google_oauth2]
 
   has_many :articles, dependent: :destroy
   has_many :posts, dependent: :destroy
@@ -21,6 +22,7 @@ class User < ApplicationRecord
   validates :name,  presence: true, length: { in: 1..10 }
   validates :age,   allow_nil: true, numericality: { greater_than_or_equal_to: 10 }
   validates :profile, length: { maximum: 200 } # 追記
+  validates :uid, uniqueness: { scope: :provider }
 
   enum gender: { male: 0, female: 1, other: 2 }
 
@@ -44,4 +46,15 @@ class User < ApplicationRecord
   def article_already_liked?(article_id)
     likes.where(article_id: article_id).exists?
   end
+
+
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.name = auth.info.name
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0,20]
+      user.confirmed_at = Time.now
+    end
+  end
+
 end

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -20,6 +20,7 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <% display_provider = provider.to_s == 'google_oauth2' ? 'Google' : OmniAuth::Utils.camelize(provider) %>
+    <%= link_to t('.sign_in_with_provider', provider: display_provider), omniauth_authorize_path(resource_name, provider), method: :post %><br />
   <% end %>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-
+  config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,8 @@ Rails.application.routes.draw do
     sessions:      'users/sessions',
     passwords:     'users/passwords',
     confirmations: 'users/confirmations',
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    omniauth_callbacks: 'users/omniauth_callbacks'
   }
 
   namespace :users do

--- a/db/migrate/20231128094823_add_oauth_to_user.rb
+++ b/db/migrate/20231128094823_add_oauth_to_user.rb
@@ -1,0 +1,11 @@
+class AddOauthToUser < ActiveRecord::Migration[6.1]
+  def change
+    unless ActiveRecord::Base.connection.column_exists?(:users, :uid)
+      add_column :users, :uid, :string
+    end
+
+    unless ActiveRecord::Base.connection.column_exists?(:users, :provider)
+      add_column :users, :provider, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_14_034516) do
+ActiveRecord::Schema.define(version: 2023_11_28_094823) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -89,6 +89,30 @@ ActiveRecord::Schema.define(version: 2023_11_14_034516) do
     t.bigint "admin_id"
     t.index ["admin_id"], name: "index_articles_on_admin_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "chat_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "chat_room_id", null: false
+    t.bigint "user_id", null: false
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["chat_room_id"], name: "index_chat_messages_on_chat_room_id"
+    t.index ["user_id"], name: "index_chat_messages_on_user_id"
+  end
+
+  create_table "chat_room_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "chat_room_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["chat_room_id"], name: "index_chat_room_users_on_chat_room_id"
+    t.index ["user_id"], name: "index_chat_room_users_on_user_id"
+  end
+
+  create_table "chat_rooms", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "inquiries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -212,6 +236,8 @@ ActiveRecord::Schema.define(version: 2023_11_14_034516) do
     t.integer "gender"
     t.integer "learning_history"
     t.string "purpose"
+    t.string "provider"
+    t.string "uid"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -224,6 +250,10 @@ ActiveRecord::Schema.define(version: 2023_11_14_034516) do
   add_foreign_key "article_comments", "users"
   add_foreign_key "articles", "admins"
   add_foreign_key "articles", "users"
+  add_foreign_key "chat_messages", "chat_rooms"
+  add_foreign_key "chat_messages", "users"
+  add_foreign_key "chat_room_users", "chat_rooms"
+  add_foreign_key "chat_room_users", "users"
   add_foreign_key "inquiries", "users"
   add_foreign_key "posts", "admins"
   add_foreign_key "posts", "users"


### PR DESCRIPTION
———

▫️概要

Googleでログイン機能の追加

———-

◽️タスク・仕様書

https://trello.com/c/D5mfqmlf

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=660020303

———-

◽️実装内容・手法

Google API によるGoogleでログイン機能

————

▫️確認事項

・動作確認
→ Google アカウントでログインできることを確認する

--------

▲確認手順

結論から言うと、今回の確認手順は結構大変です。

1. Google Cloud Platformへの登録および 
クラインアントIDと クライアントシークレットを取得する必要がある( これをenvファイルに記述する)

2. ngrokによるssl化されたURLの取得 (= httpsのurl)、
そして、Goolge Cloud PlatformでそのURLをリダイレクトURI で承認する。

※承認済みのリダイレクトURI  について下記のように記載してください。
https:**********(ngrokで取得したURL)/users/auth/google_oauth2/callback

===

・Google Cloud Platformへの登録は下記の記事が参考になります。
https://zenn.dev/batacon/articles/e9b4a88ede2889#3.-google-api%E3%81%AE%E8%A8%AD%E5%AE%9A

※記事内の6/10: 「スコープを追加または削除」で「Googleアカウントのメインのメールアドレスの参照」をチェックして「更新」したのち、「保存して次へ」。私はこの設定をせずに認証できました。

※ 下記の記述は古いので参考にしないでください(httpは使えないです)。
  9/10: アプリケーションの種類を「ウェブアプリケーション」にして、「名前」は適当に
「承認済みのリダイレクトURI」は、http://localhost:3000/auth/google_oauth2/callbackとします。

※参考: Googleが「httpsしか認めない」と書いてあるページ。

https://developers.google.com/identity/protocols/oauth2/web-server?hl=ja#uri-validation


==

・ngrok で生成した httpsの URLを指定


https://github.com/nishinotakay/teac-output-new/assets/111734087/ce6dc85a-66e9-42da-96ae-90e117367166

==
・envファイルに記載するクライアントIDとクライアントシークレット

↓ envへの書き方

GOOGLE_CLIENT_ID= '取得したクライアントID'
GOOGLE_CLIENT_SECRET= '取得したクライアントシークレット'

<img width="1382" alt="envファイルに記載すること" src="https://github.com/nishinotakay/teac-output-new/assets/111734087/e0a40c7d-1bd1-4407-a881-8dfdb1480b1a">

—————

▫️共有事項

・migrationファイルでの条件分岐について。
→ usersテーブルuid providerカラムがすでに存在する場合、uid providerカラムを追加しないように書いています。

※ FacebookログインもLINEログインも、Twitterログインも uid providerカラムを使います。SNSログインの実装で同名のカラムが大渋滞するので、タイミング悪ければ重複エラー出ると思います。そのため、すでに存在する場合はカラムを生成しません(uid providerカラムがあっても、migrationファイル自体は実行されるので、pendingエラーは出ないことを確認しています)。


