### PR TITLE
お問い合わせ詳細に問い合わせたユーザーのメールアドレスを表示

### DIFF
--- a/app/views/admins/inquiries/show.html.erb
+++ b/app/views/admins/inquiries/show.html.erb
@@ -6,11 +6,12 @@
       <textarea id="subject" name="subject" rows="2" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiry.subject %></textarea>
     </div>
     <br>
+    <div class="field mb-3">
+      <label><%= @user.name %>様のメールアドレス</label>
+      <textarea rows="2" cols="90" readonly style="resize: none; font-size: 16px;"><%= @user.email %></textarea>
+    </div>
     <div class="field">
      <label>内容</label>
       <textarea id="content" name="content" rows="9" cols="90" readonly style="resize: none; font-size: 16px;"><%= @inquiry.content %></textarea>
     </div>
 </div>
-
-
-


### PR DESCRIPTION
▫️概要

【管理側】問い合わせの詳細画面にメールアドレスを表示する。	
→お問い合わせをしたユーザーと連絡できるようにするため。

———-

◽️タスク・仕様書

https://trello.com/c/w1Fjuui7

https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit#gid=20789617

———-

◽️実装内容・手法

問い合わせ詳細画面にお問い合わせをしたユーザーのメールアドレスを表示する。
→ viewの修正のみ

————

▫️確認事項

・viewで問い合わせをしたユーザーのメールアドレスが表示されていること