### PR TITLE
【管理側】問い合わせ機能　非表示→非表示機能

### DIFF
--- a/app/controllers/admins/inquiries_controller.rb
+++ b/app/controllers/admins/inquiries_controller.rb
@@ -14,19 +14,19 @@ module Admins
       @user = @inquiry.user 
     end
 
-    def update
-      @inquiry = Inquiry.find(params[:id])
-      if @inquiry.update(hidden: !@inquiry.hidden)
-        if @inquiry.hidden
-          flash[:notice] = 'お問い合わせを非表示にしました'
-        else
-          flash[:notice] = 'お問い合わせを表示しました'
-        end
-      else
-        flash[:alert] = '更新に失敗しました'
-      end
-      redirect_to admins_inquiries_path
+def update
+  @inquiry = Inquiry.find(params[:id])
+  if @inquiry.update(hidden: !@inquiry.hidden)
+    if @inquiry.hidden
+      flash[:notice] = 'お問い合わせを非表示にしました'
+    else
+      flash[:notice] = 'お問い合わせを再表示しました'
     end
+  else
+    flash[:alert] = '更新に失敗しました'
+  end
+  redirect_to admins_inquiries_path
+end
   
     private
 

--- a/app/controllers/admins/inquiries_controller.rb
+++ b/app/controllers/admins/inquiries_controller.rb
@@ -14,19 +14,17 @@ module Admins
       @user = @inquiry.user 
     end
 
-def update
-  @inquiry = Inquiry.find(params[:id])
-  if @inquiry.update(hidden: !@inquiry.hidden)
-    if @inquiry.hidden
-      flash[:notice] = 'お問い合わせを非表示にしました'
-    else
-      flash[:notice] = 'お問い合わせを再表示しました'
+    def update
+      @inquiry = Inquiry.find(params[:id])
+      if @inquiry.update(hidden: !@inquiry.hidden)
+        if @inquiry.hidden
+          flash[:notice] = 'お問い合わせを非表示にしました'
+        else
+          flash[:notice] = 'お問い合わせを再表示しました'
+        end
+      end
+      redirect_to admins_inquiries_path
     end
-  else
-    flash[:alert] = '更新に失敗しました'
-  end
-  redirect_to admins_inquiries_path
-end
   
     private
 

--- a/app/controllers/admins/inquiries_controller.rb
+++ b/app/controllers/admins/inquiries_controller.rb
@@ -15,13 +15,17 @@ module Admins
     end
 
     def update
-      @inquiries = Inquiry.find(params[:id])
-      if @inquiries.update(hidden: true)
-         flash[:notice] = 'お問い合わせを非表示にしました'
-         redirect_to admins_inquiries_path
+      @inquiry = Inquiry.find(params[:id])
+      if @inquiry.update(hidden: !@inquiry.hidden)
+        if @inquiry.hidden
+          flash[:notice] = 'お問い合わせを非表示にしました'
+        else
+          flash[:notice] = 'お問い合わせを表示しました'
+        end
       else
-        flash[:notice] = 'お問い合わせを表示しました'
+        flash[:alert] = '更新に失敗しました'
       end
+      redirect_to admins_inquiries_path
     end
   
     private

--- a/app/controllers/admins/inquiries_controller.rb
+++ b/app/controllers/admins/inquiries_controller.rb
@@ -28,10 +28,8 @@ module Admins
   
     private
 
-
     def inquiry_params
       params.require(:inquiry).permit(:subject, :content)
-    end
-    
+    end    
   end
 end

--- a/app/views/admins/inquiries/index.html.erb
+++ b/app/views/admins/inquiries/index.html.erb
@@ -36,7 +36,7 @@
                 <li><%= link_to '詳細', admins_inquiry_path(inquiry), class:"nav-link" %></li>
                 <li>
                   <% if inquiry.hidden %>
-                    <%= link_to '表示', admins_inquiry_path(inquiry, hidden: true), method: :patch, class:"nav-link", data: { confirm: '本当に表示にしますか？' } %>
+                    <%= link_to '再表示', admins_inquiry_path(inquiry, hidden: true), method: :patch, class:"nav-link", data: { confirm: '再表示しますか？' } %>
                   <% else %>
                     <%= link_to '非表示', admins_inquiry_path(inquiry, hidden: false), method: :patch, class:"nav-link", data: { confirm: '本当に非表示にしますか？' } %>
                   <% end %>

--- a/app/views/admins/inquiries/index.html.erb
+++ b/app/views/admins/inquiries/index.html.erb
@@ -34,7 +34,13 @@
               <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px">︙</button>
               <ul class="dropdown-menu">
                 <li><%= link_to '詳細', admins_inquiry_path(inquiry), class:"nav-link" %></li>
-                <li><%= link_to '非表示', admins_inquiry_path(inquiry), method: :patch, class:"nav-link", data: { confirm: '本当に非表示にしますか？' } %></li>
+                <li>
+                  <% if inquiry.hidden %>
+                    <%= link_to '表示', admins_inquiry_path(inquiry, hidden: true), method: :patch, class:"nav-link", data: { confirm: '本当に表示にしますか？' } %>
+                  <% else %>
+                    <%= link_to '非表示', admins_inquiry_path(inquiry, hidden: false), method: :patch, class:"nav-link", data: { confirm: '本当に非表示にしますか？' } %>
+                  <% end %>
+                </li>
               </ul>
             </td>
           </tr>


### PR DESCRIPTION
概要

**問い合わせ一覧 非表示→表示にできるように実装しました。**

タスク・仕様書

https://trello.com/c/ku2NjLco/345-%E3%80%90%E7%AE%A1%E7%90%86%E5%81%B4%E3%80%91%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B%E6%A9%9F%E8%83%BD%E9%9D%9E%E8%A1%A8%E7%A4%BA%E3%81%8B%E3%82%89%E8%A1%A8%E7%A4%BA%E3%81%AB%E6%88%BB%E3%81%9B%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B%E3%80%82
https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit#gid=20789617

実装内容・手法
　　以下の手順で非表示した値が最表示できるか確認をお願いします。
　・問い合わせ一覧→非表示(ドロップダウン)→検索から非表示を選択し、再表示を選択。

添付ファイル
<img width="1006" alt="スクリーンショット 2023-12-09 0 01 57" src="https://github.com/nishinotakay/teac-output-new/assets/105785155/150a2ede-b70e-4ec6-be7d-b8ba00e7af17">
<img width="1164" alt="スクリーンショット 2023-12-08 23 55 30" src="https://github.com/nishinotakay/teac-output-new/assets/105785155/54017b98-ca41-452c-86df-bbd1ec261b0e">

