### PR TITLE
動画投稿一覧にてコメント数表示にdecorator使用

### DIFF
--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -11,4 +11,10 @@ class PostDecorator < Draper::Decorator
     end
   end
 
+  def formatted_comment_count
+    if self.post_comments.present?
+      h.content_tag(:i, '', class: 'fa-regular fa-comment fa-sm ms-auto') + object.post_comments.count.to_s  
+    end
+  end
+
 end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -12,8 +12,8 @@ class PostDecorator < Draper::Decorator
   end
 
   def formatted_comment_count
-    if self.post_comments.present?
-      h.content_tag(:i, '', class: 'fa-regular fa-comment fa-sm ms-auto') + object.post_comments.count.to_s  
+    if post_comments.present?
+      h.content_tag(:i, '', class: 'fa-regular fa-comment fa-sm ms-auto') + ' ' + post_comments.count.to_s  
     end
   end
 

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -13,8 +13,7 @@ class PostDecorator < Draper::Decorator
 
   def formatted_comment_count
     if post_comments.present?
-      h.content_tag(:i, '', class: 'fa-regular fa-comment fa-sm ms-auto') + ' ' + post_comments.count.to_s  
+      h.content_tag(:i, '', class: 'fa-regular fa-comment fa-sm ms-auto') + ' ' + post_comments.count.to_s
     end
   end
-
 end

--- a/app/decorators/users/post_comment_decorator.rb
+++ b/app/decorators/users/post_comment_decorator.rb
@@ -1,9 +1,4 @@
 class Users::PostCommentDecorator < ApplicationDecorator
   delegate_all
 
-  def formatted_comment_count
-    if post_comments.present?
-      h.content_tag(:i, '', class: 'fa-regular fa-comment fa-sm ms-auto') + post_comments.count.to_s  
-    end
-  end
 end

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -35,10 +35,8 @@
             <%= post.title %>
           </td>
           <td>
-            <%= post.decorate.formatted_likes(current_user) %>          
-            <%if post.post_comments.present? %>
-              <i class="fa-regular fa-comment fa-sm ms-auto">&nbsp;<%= post.post_comments.count %></i>
-            <% end %> 
+            <%= post.decorate.formatted_likes(current_user) %>
+            <%= post.decorate.formatted_comment_count %>
           </td>
           <td class="post-body" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= simple_format(post.body) %></td>
           <td class="post-url" width="150" onclick='window.location="<%= users_post_path(id: post.id) %>"'>


### PR DESCRIPTION
**PR概要**
動画投稿一覧にてコメント数を表示するロジックをviewからdecoratorに移しました。
表示自体はほぼ変わらずです。
アイコンとコメント数の間に半角スペースを入れたところが表示上の若干の変更です。

とても小さな修正ですがレビューよろしくお願いいたします。

**確認手順**
ユーザーでログイン後、動画投稿一覧を表示。
それぞれの環境でコメントがされているかどうか異なるかと思いますので、もしコメントがないようでしたらコメントを投稿した上で一覧での表示の確認をお願いします。
