### PR TITLE
動画一覧レイアウト修正

### DIFF
--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -4,9 +4,9 @@ class PostDecorator < Draper::Decorator
   def formatted_likes(current_user)
     if likes.present?
       if current_user&.post_already_liked?(post.id)
-        h.content_tag(:i, '', class: 'fa-solid fa-heart ml-4 mr-2') + likes.count.to_s
+        h.content_tag(:i, '', class: 'fa-solid fa-heart mr-2') + likes.count.to_s
       else
-        h.content_tag(:i, '', class: 'fa-regular fa-heart ml-4 mr-2') + likes.count.to_s
+        h.content_tag(:i, '', class: 'fa-regular fa-heart mr-2') + likes.count.to_s
       end
     end
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,3 +7,4 @@
 import './count';
 import './count_t';
 import '../stylesheets/users/inquiries.scss';
+import '../stylesheets/users/posts.scss';

--- a/app/javascript/stylesheets/users/posts.scss
+++ b/app/javascript/stylesheets/users/posts.scss
@@ -82,3 +82,12 @@
   background-color: white;
   border-radius: 5px;
 }
+
+/* 動画投稿一覧  */
+.bold-title {
+  font-weight: bold;
+}
+
+.gray-content {
+  color: gray;
+} 

--- a/app/javascript/stylesheets/users/posts.scss
+++ b/app/javascript/stylesheets/users/posts.scss
@@ -89,5 +89,6 @@
 }
 
 .gray-content {
-  color: gray;
-} 
+  color: gray; /* グレーに変更 */
+  font-size: 0.9rem; /* 文字サイズを少し小さく変更 */
+}

--- a/app/javascript/stylesheets/users/posts.scss
+++ b/app/javascript/stylesheets/users/posts.scss
@@ -89,6 +89,13 @@
 }
 
 .gray-content {
-  color: gray; /* グレーに変更 */
-  font-size: 0.9rem; /* 文字サイズを少し小さく変更 */
+  color: gray;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
 }

--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -14,46 +14,53 @@
   <%= render partial: 'modal', locals: { posts: @posts, order: params[:order] } %>
 <% end %>
 
-<table class="table table-hover table-scroll">
-  <thead>
-    <tr>
-      <th>タイトル</th>
-      <th>内容</th>
-      <th>Youtube</th>
-      <th>投稿者</th>
-      <th>投稿日</th>
-      <th></th>
-    </tr>
-  </thead>
+<% if @posts&.exists? %>
+      <div class="row">
+        <% @posts.each do |post| %>
+          <div class="col-md-4">
+            <div class="card mb-3">
+              <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              <div class="card-body mx-3">
+                <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
+                <h5 class="card-title bold-title" onclick="window.location='<%= admins_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
+                
+                <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
+                <div class="card-text post-body gray-content" onclick='window.location="<%= admins_post_path(id: post.id) %>"' title="<%= post.body %>">
+                  <%= simple_format(sanitize(truncated_content, tags: [])) %>
+                </div>
 
-  <tbody>      
-    <% if @posts&.exists? %>
-      <% @posts.each do |post| %>
-        <tr>
-          <td onclick='window.location="<%= admins_post_path(id: post.id) %>"'><%= post.title %></td>
-          <td onclick='window.location="<%= admins_post_path(id: post.id) %>"'><%= simple_format(post.body) %></td>
-          <td width="150" onclick='window.location="<%= admins_post_path(id: post.id) %>"'>
-            <iframe width="289" height="180" src="https://www.youtube.com/embed/<%=post.youtube_url %>"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-          </td>
-          <td onclick='window.location="<%= admins_post_path(id: post.id) %>"'><%= post.admin ? post.admin.name : post.user.name %></td>
-          <td onclick='window.location="<%= admins_post_path(id: post.id) %>"'><%= post.created_at.strftime('%Y/%m/%d') %></td> 
-          <td>
-            <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
-            <ul class="dropdown-menu">
-              <% if post.admin_id == current_admin.id %>
-                <li><%= link_to '閲覧', admins_post_path(post), class:"nav-link" %></li>
-                <li><%= link_to '編集', edit_admins_post_path(post), class:"nav-link" %></li>
-                <li><%= link_to '削除', admins_post_path(post), method: :delete, class:"nav-link", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %></li>
-              <% else %>
-                <li><%= link_to '閲覧', admins_post_path(post), class:"nav-link" %></li>
-              <% end %>
-            </ul>
-          </td> 
-        </tr>
-      <% end %>
+                <div class="card-text post-author" onclick='window.location="<%= admins_post_path(id: post.id) %>"'>
+                  <%= post.admin ? post.admin.name : post.user.name %>
+                </div>
+                
+                <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
+                  <div>
+                    <%= post.decorate.formatted_likes(current_user) %>
+                    <%= post.decorate.formatted_comment_count %>
+                  </div>
+                  <div style="display: flex; align-items: center;">
+                    <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
+                      <%= post.created_at.strftime('%Y-%m-%d') %>
+                    </time>
+                    <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
+                    <ul class="dropdown-menu">
+                      <% if post.admin_id == current_admin.id %>
+                        <li><%= link_to '閲覧', admins_post_path(id: post.id), class: "nav-link" %></li>
+                        <li><%= link_to '編集', edit_admins_post_path(id: post.id), class: "nav-link" %></li>
+                        <li><%= link_to '削除', admins_post_path(id: post.id), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
+                      <% else %>
+                        <li><%= link_to '閲覧', admins_post_path(id: post.id), class: "nav-link" %></li>
+                      <% end %>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <%= render 'users/shared/table_without_record' %>
     <% end %>
-  </tbody>
-</table>
+
 <%= paginate @posts, theme: 'bootstrap-5' %>

--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -15,52 +15,52 @@
 <% end %>
 
 <% if @posts&.exists? %>
-      <div class="row">
-        <% @posts.each do |post| %>
-          <div class="col-md-4">
-            <div class="card mb-3">
-              <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-              <div class="card-body mx-3">
-                <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
-                <h5 class="card-title bold-title" onclick="window.location='<%= admins_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
-                
-                <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
-                <div class="card-text post-body gray-content" onclick='window.location="<%= admins_post_path(id: post.id) %>"' title="<%= post.body %>">
-                  <%= simple_format(sanitize(truncated_content, tags: [])) %>
-                </div>
+  <div class="row">
+    <% @posts.each do |post| %>
+      <div class="col-md-4">
+        <div class="card mb-3">
+          <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <div class="card-body mx-3">
+            <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
+            <h5 class="card-title bold-title" onclick="window.location='<%= admins_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
+            
+            <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
+            <div class="card-text post-body gray-content" onclick='window.location="<%= admins_post_path(id: post.id) %>"' title="<%= post.body %>">
+              <%= simple_format(sanitize(truncated_content, tags: [])) %>
+            </div>
 
-                <div class="card-text post-author" onclick='window.location="<%= admins_post_path(id: post.id) %>"'>
-                  <%= post.admin ? post.admin.name : post.user.name %>
-                </div>
-                
-                <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
-                  <div>
-                    <%= post.decorate.formatted_likes(current_user) %>
-                    <%= post.decorate.formatted_comment_count %>
-                  </div>
-                  <div style="display: flex; align-items: center;">
-                    <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
-                      <%= post.created_at.strftime('%Y-%m-%d') %>
-                    </time>
-                    <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
-                    <ul class="dropdown-menu">
-                      <% if post.admin_id == current_admin.id %>
-                        <li><%= link_to '閲覧', admins_post_path(id: post.id), class: "nav-link" %></li>
-                        <li><%= link_to '編集', edit_admins_post_path(id: post.id), class: "nav-link" %></li>
-                        <li><%= link_to '削除', admins_post_path(id: post.id), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
-                      <% else %>
-                        <li><%= link_to '閲覧', admins_post_path(id: post.id), class: "nav-link" %></li>
-                      <% end %>
-                    </ul>
-                  </div>
-                </div>
+            <div class="card-text post-author" onclick='window.location="<%= admins_post_path(id: post.id) %>"'>
+              <%= post.admin ? post.admin.name : post.user.name %>
+            </div>
+            
+            <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
+              <div>
+                <%= post.decorate.formatted_likes(current_user) %>
+                <%= post.decorate.formatted_comment_count %>
+              </div>
+              <div style="display: flex; align-items: center;">
+                <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
+                  <%= post.created_at.strftime('%Y-%m-%d') %>
+                </time>
+                <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
+                <ul class="dropdown-menu">
+                  <% if post.admin_id == current_admin.id %>
+                    <li><%= link_to '閲覧', admins_post_path(id: post.id), class: "nav-link" %></li>
+                    <li><%= link_to '編集', edit_admins_post_path(id: post.id), class: "nav-link" %></li>
+                    <li><%= link_to '削除', admins_post_path(id: post.id), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
+                  <% else %>
+                    <li><%= link_to '閲覧', admins_post_path(id: post.id), class: "nav-link" %></li>
+                  <% end %>
+                </ul>
               </div>
             </div>
           </div>
-        <% end %>
+        </div>
       </div>
-    <% else %>
-      <%= render 'users/shared/table_without_record' %>
     <% end %>
+  </div>
+<% else %>
+  <%= render 'users/shared/table_without_record' %>
+<% end %>
 
 <%= paginate @posts, theme: 'bootstrap-5' %>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -25,14 +25,14 @@
                 <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
                 <h5 class="card-title bold-title" onclick="window.location='<%= users_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
                 
-                <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 45, omission: '...') %>
-                <p class="card-text post-body" id="gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
+                <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
+                <div class="card-text post-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
                   <%= simple_format(sanitize(truncated_content, tags: [])) %>
-                </p>
+                </div>
 
-                <p class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
+                <div class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
                   <%= post.admin ? post.admin.name : post.user.name %>
-                </p>
+                </div>
                 
                 <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
                   <div>
@@ -44,6 +44,15 @@
                       <%= post.created_at.strftime('%Y-%m-%d') %>
                     </time>
                     <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
+                    <ul class="dropdown-menu">
+                      <% if post.user_id == current_user.id %>
+                        <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>
+                        <li><%= link_to '編集', edit_users_post_path(id: post.id), class: "nav-link" %></li>
+                        <li><%= link_to '削除', users_post_path(id: post.id), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
+                      <% else %>
+                        <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>
+                      <% end %>
+                    </ul>
                   </div>
                 </div>
               </div>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -1,4 +1,10 @@
 <%= javascript_pack_tag "users/index_articles_and_dashboards" %>
+<%
+=begin%>
+ <%= stylesheet_link_tag 'users/posts', media: 'all', 'data-turbolinks-track': 'reload' %> 
+<%
+=end%>
+
 <% provide(:title,  "動画投稿一覧") %>
 <%= form_tag(users_posts_path, :method => "get") do %>
   <button type="button" class="btn btn-success sort-modal-btn ml-5" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
@@ -14,22 +20,54 @@
   <%= render partial: 'modal', locals: { posts: @posts, order: params[:order] } %>
 <% end %>
 
-<table class="table table-hover table-scroll">
-  <thead>
-    <tr>
-      <th class="col-sm-2">タイトル</th>
-      <th class="col-sm-1"></th>
-      <th class="col-sm-3">内容</th>
-      <th>Youtube</th>
-      <th>投稿者</th>
-      <th class="col-sm-1">投稿日</th>
-      <th class="col-sm-1"></th>
-    </tr>
-  </thead>
-
-  <tbody>      
     <% if @posts&.exists? %>
-      <% @posts.each do |post| %>
+      <div class="row">
+        <% @posts.each do |post| %>
+          <div class="col-md-4">
+            <div class="card mb-3">
+              <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              <div class="card-body">
+                <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
+                <h5 class="card-title bold-title" onclick="window.location='<%= users_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
+                
+                <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 45, omission: '...') %>
+                <p class="card-text post-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
+                  <%= simple_format(sanitize(truncated_content, tags: [])) %>
+                </p>
+                
+                <p class="card-text">
+                  <%= post.decorate.formatted_likes(current_user) %>
+                  <%= post.decorate.formatted_comment_count %>
+                </p>
+                <p class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
+                  <%= post.admin ? post.admin.name : post.user.name %>
+                </p>
+                <p class="card-text post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
+                  <%= post.created_at.strftime('%Y/%m/%d') %>
+                </p>
+                <div class="dropdown">
+                  <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px">︙</button>
+                  <ul class="dropdown-menu">
+                    <% if post.user_id == current_user.id %>
+                      <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
+                      <li><%= link_to '編集', edit_users_post_path(post), class:"nav-link", id:"post-edit" %></li>
+                      <li><%= link_to '削除', users_post_path(post), method: :delete, class:"nav-link", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %></li>
+                    <% else %>
+                      <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+
+
+      <%
+=begin%>
+ <% @posts.each do |post| %>
         <tr>
           <td class="post-title" onclick="window.location='<%= users_post_path(id: post.id) %>'">
             <%= post.title %>
@@ -57,10 +95,12 @@
             </ul>
           </td> 
         </tr>
-      <% end %>
+      <% end %> 
+<%
+=end%>
     <% else %>
       <%= render 'users/shared/table_without_record' %>
     <% end %>
-  </tbody>
-</table>
+
+
 <%= paginate @posts, theme: 'bootstrap-5' %>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -1,9 +1,4 @@
 <%= javascript_pack_tag "users/index_articles_and_dashboards" %>
-<%
-=begin%>
- <%= stylesheet_link_tag 'users/posts', media: 'all', 'data-turbolinks-track': 'reload' %> 
-<%
-=end%>
 
 <% provide(:title,  "動画投稿一覧") %>
 <%= form_tag(users_posts_path, :method => "get") do %>
@@ -26,78 +21,36 @@
           <div class="col-md-4">
             <div class="card mb-3">
               <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-              <div class="card-body">
+              <div class="card-body mx-3">
                 <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
                 <h5 class="card-title bold-title" onclick="window.location='<%= users_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
                 
                 <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 45, omission: '...') %>
-                <p class="card-text post-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
+                <p class="card-text post-body" id="gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
                   <%= simple_format(sanitize(truncated_content, tags: [])) %>
                 </p>
-                
-                <p class="card-text">
-                  <%= post.decorate.formatted_likes(current_user) %>
-                  <%= post.decorate.formatted_comment_count %>
-                </p>
+
                 <p class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
                   <%= post.admin ? post.admin.name : post.user.name %>
                 </p>
-                <p class="card-text post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
-                  <%= post.created_at.strftime('%Y/%m/%d') %>
-                </p>
-                <div class="dropdown">
-                  <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px">︙</button>
-                  <ul class="dropdown-menu">
-                    <% if post.user_id == current_user.id %>
-                      <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
-                      <li><%= link_to '編集', edit_users_post_path(post), class:"nav-link", id:"post-edit" %></li>
-                      <li><%= link_to '削除', users_post_path(post), method: :delete, class:"nav-link", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %></li>
-                    <% else %>
-                      <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
-                    <% end %>
-                  </ul>
+                
+                <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
+                  <div>
+                    <%= post.decorate.formatted_likes(current_user) %>
+                    <%= post.decorate.formatted_comment_count %>
+                  </div>
+                  <div style="display: flex; align-items: center;">
+                    <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
+                      <%= post.created_at.strftime('%Y-%m-%d') %>
+                    </time>
+                    <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         <% end %>
       </div>
-
-
-
-      <%
-=begin%>
- <% @posts.each do |post| %>
-        <tr>
-          <td class="post-title" onclick="window.location='<%= users_post_path(id: post.id) %>'">
-            <%= post.title %>
-          </td>
-          <td>
-            <%= post.decorate.formatted_likes(current_user) %>
-            <%= post.decorate.formatted_comment_count %>
-          </td>
-          <td class="post-body" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= simple_format(post.body) %></td>
-          <td class="post-url" width="150" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
-            <iframe width="289" height="180" src="https://www.youtube.com/embed/<%=post.youtube_url %>"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-          </td>
-          <td class="post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.admin ? post.admin.name : post.user.name %></td>
-          <td class="post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.created_at.strftime('%Y/%m/%d') %></td> 
-          <td>
-            <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
-            <ul class="dropdown-menu">
-              <% if post.user_id == current_user.id %>
-                <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
-                <li><%= link_to '編集', edit_users_post_path(post), class:"nav-link", id:"post-edit" %></li>
-                <li><%= link_to '削除', users_post_path(post), method: :delete, class:"nav-link", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %></li>
-              <% else %>
-                <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
-              <% end %>
-            </ul>
-          </td> 
-        </tr>
-      <% end %> 
-<%
-=end%>
     <% else %>
       <%= render 'users/shared/table_without_record' %>
     <% end %>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -15,54 +15,53 @@
   <%= render partial: 'modal', locals: { posts: @posts, order: params[:order] } %>
 <% end %>
 
-    <% if @posts&.exists? %>
-      <div class="row">
-        <% @posts.each do |post| %>
-          <div class="col-md-4">
-            <div class="card mb-3">
-              <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-              <div class="card-body mx-3">
-                <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
-                <h5 class="card-title bold-title" onclick="window.location='<%= users_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
-                
-                <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
-                <div class="card-text post-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
-                  <%= simple_format(sanitize(truncated_content, tags: [])) %>
-                </div>
+<% if @posts&.exists? %>
+  <div class="row">
+    <% @posts.each do |post| %>
+      <div class="col-md-4">
+        <div class="card mb-3">
+          <iframe width="100%" height="200" src="https://www.youtube.com/embed/<%= post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <div class="card-body mx-3">
+            <% truncated_title = truncate(post.title, length: 20, omission: '...') %>
+            <h5 class="card-title bold-title" onclick="window.location='<%= users_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
+            
+            <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
+            <div class="card-text post-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
+              <%= simple_format(sanitize(truncated_content, tags: [])) %>
+            </div>
 
-                <div class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
-                  <%= post.admin ? post.admin.name : post.user.name %>
-                </div>
-                
-                <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
-                  <div>
-                    <%= post.decorate.formatted_likes(current_user) %>
-                    <%= post.decorate.formatted_comment_count %>
-                  </div>
-                  <div style="display: flex; align-items: center;">
-                    <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
-                      <%= post.created_at.strftime('%Y-%m-%d') %>
-                    </time>
-                    <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
-                    <ul class="dropdown-menu">
-                      <% if post.user_id == current_user.id %>
-                        <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>
-                        <li><%= link_to '編集', edit_users_post_path(id: post.id), class: "nav-link" %></li>
-                        <li><%= link_to '削除', users_post_path(id: post.id), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
-                      <% else %>
-                        <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>
-                      <% end %>
-                    </ul>
-                  </div>
-                </div>
+            <div class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
+              <%= post.admin ? post.admin.name : post.user.name %>
+            </div>
+            
+            <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">
+              <div>
+                <%= post.decorate.formatted_likes(current_user) %>
+                <%= post.decorate.formatted_comment_count %>
+              </div>
+              <div style="display: flex; align-items: center;">
+                <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
+                  <%= post.created_at.strftime('%Y-%m-%d') %>
+                </time>
+                <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
+                <ul class="dropdown-menu">
+                  <% if post.user_id == current_user.id %>
+                    <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>
+                    <li><%= link_to '編集', edit_users_post_path(id: post.id), class: "nav-link" %></li>
+                    <li><%= link_to '削除', users_post_path(id: post.id), method: :delete, data: {confirm: "選択した記事を削除します。"}, class: "nav-link" %></li>
+                  <% else %>
+                    <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>
+                  <% end %>
+                </ul>
               </div>
             </div>
           </div>
-        <% end %>
+        </div>
       </div>
-    <% else %>
-      <%= render 'users/shared/table_without_record' %>
     <% end %>
-
+  </div>
+<% else %>
+  <%= render 'users/shared/table_without_record' %>
+<% end %>
 
 <%= paginate @posts, theme: 'bootstrap-5' %>


### PR DESCRIPTION
**PR概要**
動画一覧にていいねやコメント数の表示が増えたことにより、レイアウトが窮屈で見づらくなっていました。
そのため、YouTubeのようなカード形式に変更しました。

仕様書↓
https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=1822374234

**変更内容**

- テーブル形式からカード形式に変更。
- タイトルや内容の文字数が一定以上になるとその後の文字を「...」で表示。
- 内容のフォントサイズを若干小さく、グレー色に変更。
- いいね、コメント数、投稿日時、三点リーダを１行に表示。

![スクリーンショット 2023-12-22 13 39 01](https://github.com/nishinotakay/teac-output-new/assets/100989880/d307c6f0-c769-4783-b473-22421cc2316a)

