### PR TITLE
チャットメッセージに投稿日時を表示しました。

### DIFF
--- a/app/javascript/stylesheets/users/chat_rooms_show.scss
+++ b/app/javascript/stylesheets/users/chat_rooms_show.scss
@@ -105,6 +105,10 @@
   white-space: pre-wrap;
 }
 
+.chat-message-post-date-time {
+  margin-top: auto;
+}
+
 .chat-message-current-user {
   display: flex;
   justify-content: flex-end;

--- a/app/views/users/chat_messages/_chat_message.html.erb
+++ b/app/views/users/chat_messages/_chat_message.html.erb
@@ -3,9 +3,11 @@
     <div class="chat-message-partner">
       <%= image_tag @user_profile_image, class: "chat-room-partner-img" %>
       <div class="chat-message-content"><%= chat_message.content %></div>
+      <div class="chat-message-post-date-time"><%= l(chat_message.created_at, format: :short) %></div>
     </div>
   <% else %>
-    <div class="chat-message-current-user">
+    <div class="chat-message-current-user" data-date="<%= chat_message.created_at.to_i %>">
+      <div class="chat-message-post-date-time"><%= l(chat_message.created_at, format: :short) %></div>
       <div class="chat-message-content main-color-bg"><%= chat_message.content %></div>
     </div>
   <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -47,6 +47,7 @@ ja:
       default: "%Y/%m/%d"
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
+      time: '%H:%M'
     month_names:
     - 
     - 1月


### PR DESCRIPTION
**【PR概要】**
　チャットメッセージに投稿日時を表示しました。

**【実装内容】**
　LINEトーク画面モデルです。
　チャットメッセージ横下に投稿日時表示


**【確認の流れ】**
　チャットメッセージ送信後に非同期で投稿日時表示されます。


**【ご指摘内容　※指摘あれば】**
　LINEのように、投稿した日が中央あたりに表示されたり、未読通知等チャレンジしましたが、全くできず、chat GPT に頼ると
　スクショ②のようには出来ましたが、頼りすぎて本来の実力と離れていくと考え、辞めました🙇‍♂️
　JSの学習を続けて、今後またチャレンジさせてください🙇‍♂️

**【実装画面スクリーンショットのスプレッドシートのリンク】**
　スクショ①　※今回PRのイメージ
<img width="847" alt="スクリーンショット 2023-12-22 17 46 01" src="https://github.com/nishinotakay/teac-output-new/assets/68493893/3cf7fa8b-88ca-476f-ba1b-98042f7a845d">


スクショ②　※ こちらはチャレンジして諦めました。このPRには含まないイメージです。
<img width="844" alt="スクリーンショット 2023-12-21 13 35 42" src="https://github.com/nishinotakay/teac-output-new/assets/68493893/bae0dc0c-1d68-4994-b510-3c66f3362fa6">

