### PR TITLE
【一般ユーザー】特定のユーザーの投稿動画一覧ページを追加

### DIFF
--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -64,7 +64,7 @@ module Users
     end
 
     def index_user
-      user = User.find(params[:id])
+      user = User.find(params[:user_id])
       @posts = user.posts.filtered_and_ordered_posts(params, params[:page], 30)
     end
 

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class PostsController < Users::Base
-    before_action :authenticate_user!, only: %i[show index new create edit update destroy ]
-    before_action :set_post, only: %i[show edit update destroy ]
+    before_action :authenticate_user!, only: %i[show index new create edit update destroy index_user]
+    before_action :set_post, only: %i[show edit update destroy]
     before_action :prevent_url, only: %i[edit update destroy]
 
     def index

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -64,8 +64,8 @@ module Users
     end
 
     def index_user
-      user = User.find(params[:user_id])
-      @posts = user.posts.filtered_and_ordered_posts(params, params[:page], 30)
+      @user = User.find(params[:user_id])
+      @posts = @user.posts.filtered_and_ordered_posts(params, params[:page], 30)
     end
 
     private

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -63,6 +63,11 @@ module Users
       end
     end
 
+    def index_user
+      user = User.find(params[:id])
+      @posts = user.posts
+    end
+
     private
 
       def set_post

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class PostsController < Users::Base
-    before_action :authenticate_user!, only: %i[show index new create edit update destroy]
-    before_action :set_post, only: %i[show edit update destroy]
+    before_action :authenticate_user!, only: %i[show index new create edit update destroy ]
+    before_action :set_post, only: %i[show edit update destroy ]
     before_action :prevent_url, only: %i[edit update destroy]
 
     def index
@@ -65,7 +65,7 @@ module Users
 
     def index_user
       user = User.find(params[:id])
-      @posts = user.posts
+      @posts = user.posts.filtered_and_ordered_posts(params, params[:page], 30)
     end
 
     private

--- a/app/views/users/posts/_modal.html.erb
+++ b/app/views/users/posts/_modal.html.erb
@@ -24,14 +24,14 @@
           </div>
         </div>
         <div class="filter-modal" style="display: none;"> 
-         <% unless params[:user_id] %>
+          <% unless params[:user_id] %>
           <div class="form-group row my-4">
             <label for="input-author" class="col-sm-4 col-form-label"><%= Article.human_attribute_name(:user) %></label>
             <div class="col-md-8">
               <input type="text" aria-label="author" id="input-author" class="form-control" value="<%= params[:author] %>">
             </div>
           </div>
-         <% end %>
+          <% end %>
           <div class="form-group row my-4">
             <label for="input-title" class="col-sm-4 col-form-label"><%= Post.human_attribute_name(:title) %></label>
             <div class="col-md-8">

--- a/app/views/users/posts/_modal.html.erb
+++ b/app/views/users/posts/_modal.html.erb
@@ -24,12 +24,14 @@
           </div>
         </div>
         <div class="filter-modal" style="display: none;"> 
+         <% unless params[:user_id] %>
           <div class="form-group row my-4">
             <label for="input-author" class="col-sm-4 col-form-label"><%= Article.human_attribute_name(:user) %></label>
             <div class="col-md-8">
               <input type="text" aria-label="author" id="input-author" class="form-control" value="<%= params[:author] %>">
             </div>
           </div>
+         <% end %>
           <div class="form-group row my-4">
             <label for="input-title" class="col-sm-4 col-form-label"><%= Post.human_attribute_name(:title) %></label>
             <div class="col-md-8">

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -42,7 +42,7 @@
           <td class="post-url" width="150" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
             <iframe width="289" height="180" src="https://www.youtube.com/embed/<%=post.youtube_url %>"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           </td>
-          <td class="post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.admin ? post.admin.name : post.user.name %></td>
+          <td class="post-author"><%=link_to post.admin ? post.admin.name : post.user.name, index_user_users_posts_path(user_id: post.admin ? post.admin.id : post.user.id ) %></td>
           <td class="post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.created_at.strftime('%Y/%m/%d') %></td> 
           <td>
             <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -42,7 +42,7 @@
           <td class="post-url" width="150" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
             <iframe width="289" height="180" src="https://www.youtube.com/embed/<%=post.youtube_url %>"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           </td>
-          <td class="post-author"><%=link_to post.admin ? post.admin.name : post.user.name, index_user_users_posts_path(user_id: post.admin ? post.admin.id : post.user.id ) %></td>
+          <td class="post-author"><%=link_to post.admin ? post.admin.name : post.user.name, index_user_users_user_posts_path(user_id: post.admin ? post.admin.id : post.user.id ) %></td>
           <td class="post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.created_at.strftime('%Y/%m/%d') %></td> 
           <td>
             <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -30,8 +30,8 @@
               <%= simple_format(sanitize(truncated_content, tags: [])) %>
             </div>
 
-            <div class="card-text post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
-              <%= post.admin ? post.admin.name : post.user.name %>
+            <div class="card-text post-author">
+              <%=link_to post.admin ? post.admin.name : post.user.name, index_user_users_user_posts_path(post.admin ? post.admin.id : post.user.id ) %>
             </div>
             
             <div class="card-text-container" style="display: flex; justify-content: space-between; align-items: center;">

--- a/app/views/users/posts/index_user.html.erb
+++ b/app/views/users/posts/index_user.html.erb
@@ -1,0 +1,4 @@
+<% @posts.each do |post| %>
+  <%= post.title %>
+  <%= post.body %>
+<% end %>

--- a/app/views/users/posts/index_user.html.erb
+++ b/app/views/users/posts/index_user.html.erb
@@ -1,4 +1,67 @@
-<% @posts.each do |post| %>
-  <%= post.title %>
-  <%= post.body %>
+<%= javascript_pack_tag "users/index_articles_and_dashboards" %>
+<% provide(:title,  "動画投稿一覧") %>
+<%= form_tag(users_posts_path, :method => "get") do %>
+  <button type="button" class="btn btn-success sort-modal-btn ml-5" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
+    並べ替え
+  </button>
+  <button type="button" class="btn btn-success filter-modal-btn ml-3" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
+    絞り込み検索
+  </button>
+  <% if params[:reset] %>
+    <button type="button" class="btn btn-outline-success reset-btn ml-3">リセット</button>
+  <% end %>
+
+  <%= render partial: 'modal', locals: { posts: @posts, order: params[:order] } %>
 <% end %>
+
+<table class="table table-hover table-scroll">
+  <thead>
+    <tr>
+      <th class="col-sm-2">タイトル</th>
+      <th class="col-sm-1"></th>
+      <th class="col-sm-3">内容</th>
+      <th>Youtube</th>
+      <th>投稿者</th>
+      <th class="col-sm-1">投稿日</th>
+      <th class="col-sm-1"></th>
+    </tr>
+  </thead>
+
+
+  <tbody>      
+    <% if @posts&.exists? %>
+      <% @posts.each do |post| %>
+        <tr>
+          <td class="post-title" onclick="window.location='<%= users_post_path(id: post.id) %>'">
+            <%= post.title %>
+          </td>
+          <td>
+            <%= post.decorate.formatted_likes(current_user) %>
+            <%= post.decorate.formatted_comment_count %>
+          </td>
+          <td class="post-body" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= simple_format(post.body) %></td>
+          <td class="post-url" width="150" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
+            <iframe width="289" height="180" src="https://www.youtube.com/embed/<%=post.youtube_url %>"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          </td>
+          <td class="post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.admin ? post.admin.name : post.user.name %></td>
+          <td class="post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.created_at.strftime('%Y/%m/%d') %></td> 
+          <td>
+            <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
+            <ul class="dropdown-menu">
+              <% if post.user_id == current_user.id %>
+                <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
+                <li><%= link_to '編集', edit_users_post_path(post), class:"nav-link", id:"post-edit" %></li>
+                <li><%= link_to '削除', users_post_path(post), method: :delete, class:"nav-link", data: {confirm: "#{post.title}を削除してもよろしいですか？"} %></li>
+              <% else %>
+                <li><%= link_to '閲覧', users_post_path(post), class:"nav-link" %></li>
+              <% end %>
+            </ul>
+          </td> 
+        </tr>
+      <% end %>
+    <% else %>
+      <%= render 'users/shared/table_without_record' %>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @posts, theme: 'bootstrap-5' %>

--- a/app/views/users/posts/index_user.html.erb
+++ b/app/views/users/posts/index_user.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_pack_tag "users/index_articles_and_dashboards" %>
-<% provide(:title,  "動画投稿一覧") %>
+<% provide(:title,  "#{@user.name}の投稿動画一覧") %>
 <%= form_tag(users_posts_path, :method => "get") do %>
   <button type="button" class="btn btn-success sort-modal-btn ml-5" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
     並べ替え

--- a/app/views/users/posts/index_user.html.erb
+++ b/app/views/users/posts/index_user.html.erb
@@ -21,7 +21,6 @@
       <th class="col-sm-1"></th>
       <th class="col-sm-3">内容</th>
       <th>Youtube</th>
-      <th>投稿者</th>
       <th class="col-sm-1">投稿日</th>
       <th class="col-sm-1"></th>
     </tr>
@@ -43,7 +42,6 @@
           <td class="post-url" width="150" onclick='window.location="<%= users_post_path(id: post.id) %>"'>
             <iframe width="289" height="180" src="https://www.youtube.com/embed/<%=post.youtube_url %>"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           </td>
-          <td class="post-author" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.admin ? post.admin.name : post.user.name %></td>
           <td class="post-created_at" onclick='window.location="<%= users_post_path(id: post.id) %>"'><%= post.created_at.strftime('%Y/%m/%d') %></td> 
           <td>
             <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,9 @@ Rails.application.routes.draw do
     end
     resources :users, only: [:show]
     resources :posts do
+      member do
+        get 'index_user'
+      end
       resources :post_comments, only: %i[create destroy update]
       resource :likes, only: [] do
         post 'post_create', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     end
     resources :users, only: [:show]
     resources :posts do
-      member do
+      collection do
         get 'index_user'
       end
       resources :post_comments, only: %i[create destroy update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,11 +58,13 @@ Rails.application.routes.draw do
         delete 'article_destroy', on: :member
       end
     end
+    resources :users do
+      resource :posts, only: [] do
+        get 'index_user', on: :member
+      end
+    end
     resources :users, only: [:show]
     resources :posts do
-      collection do
-        get 'index_user'
-      end
       resources :post_comments, only: %i[create destroy update]
       resource :likes, only: [] do
         post 'post_create', on: :member


### PR DESCRIPTION
▫️概要

【一般ユーザー】特定のユーザーの投稿動画一覧ページを作成する。

動画投稿一覧 の投稿者の名前をクリックすると、
その投稿者が投稿した動画一覧を表示することができる。

———-

◽️タスク・仕様書

https://trello.com/c/k7Lf2z1H

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=1822374234

———-

◽️実装内容・手法

・投稿者の動画一覧ページを作成
→ 投稿動画一覧の投稿者名をクリックすると遷移

※つぶやき一覧ページにおいて投稿者の名前をクリックすると つぶやき一覧に遷移したので、
一覧ページへの導線はユーザー名のテキストリンクとしました。

※ YouTubeもユーザー名( チャンネル名)をクリックすると、
ユーザーが投稿した動画が確認できるページに遷移できるので、これを見本とすることにしました。

————

▫️確認事項

動作確認をお願いします。

・投稿動画一覧の投稿者名をクリックして、投稿者の動画一覧ページに遷移可能であるか
・投稿者の動画一覧ページにて検索・並び替えが正常に行えるか

<img width="1438" alt="投稿者の名前をクリックする" src="https://github.com/nishinotakay/teac-output-new/assets/111734087/e2ee5d97-5f6c-4929-bfa4-a97515228814">


————

▫️補足事項

・Draftプルリクに上がっている、【管理側】登録ユーザー詳細画面_投稿した一覧を確認できるようにする。において、
　つぶやき一覧が存在しないと記載しましたが、よく確認したら つぶやき一覧ページは存在していました。
　そのため、このプルリクがapproveされたら、管理者側から記事・動画・つぶやきの一覧に遷移できる機能の実装に戻ります。
