### PR TITLE
動画投稿詳細ページレイアウト修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,12 +2,13 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.0.3
   Exclude:
     - 'db/**/*'                                   # DBのマイグレーション関連ファイル
     - 'vendor/**/*'                               # ベンダーが提供するファイル
     - 'bin/{bundle,rails,rake,setup,update,yarn}' # Railsが生成するスクリプト
   SuggestExtensions: false
+  NewCops: enable
 
 # エイリアスの指定を `alias_method` に統一
 Style/Alias:
@@ -123,7 +124,7 @@ Layout/LineLength:
   Exclude:
     - 'app/admin/**/*'                  # ActiveAdminのDSL
     - 'app/libs/admins/components/**/*' # ActiveAdminのコンポーネントDSL
-  IgnoredPatterns:
+  AllowedPatterns:
     - "'.+'"                                                               # 文字リテラルが含まれる行
     - '".+"'                                                               # 文字リテラルが含まれる行
     - '#.+'                                                                # コメントが含まれる行
@@ -176,7 +177,7 @@ Metrics/BlockLength:
     - 'spec/**/*'                             # RspecのDSL
     - 'lib/tasks/helpers/test_data_helper.rb' # テストデータ定義
     - '*.gemspec'                             # Gem定義
-  ExcludedMethods:
+  AllowedMethods:
     - 'configure'
     - 'class_eval'
     - 'extended'

--- a/app/javascript/stylesheets/users/posts.scss
+++ b/app/javascript/stylesheets/users/posts.scss
@@ -103,8 +103,8 @@
 /* 動画詳細ページ */
 
 .post-show {
-  margin-left: 20px;
-  margin-right: 20px;
+  margin-left: 30px;
+  margin-right: 30px;
 }
 
 .post-title,
@@ -136,10 +136,11 @@
   align-items: center;
   margin-top: 10px;
   margin-left: 20px;
+  margin-right: 40px;
 }
 
-.post-author,
-.timestamp-and-menu {
+.post-details,
+.post-author {
   margin-right: 10px;
 }
 
@@ -148,6 +149,6 @@
   margin-bottom: 0;
 }
 
-.btn-post-show-menu {
+.post-details {
   margin-right: 40px;
 }

--- a/app/javascript/stylesheets/users/posts.scss
+++ b/app/javascript/stylesheets/users/posts.scss
@@ -99,3 +99,55 @@
   justify-content: space-between;
   height: 100%;
 }
+
+/* 動画詳細ページ */
+
+.post-show {
+  margin-left: 20px;
+  margin-right: 20px;
+}
+
+.post-title,
+.post-body {
+  margin-left: 20px;
+}
+
+.video-container {
+  position: relative;
+  width: 50%;
+  height: 0%;
+  padding-bottom: 28.125%; /* 16:9 aspect ratio */
+  margin-bottom: 10px; /* Add margin for spacing */
+  margin-left: 30px;
+}
+
+.video-container iframe {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  border-radius: 10px;
+}
+
+.post-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+  margin-left: 20px;
+}
+
+.post-author,
+.timestamp-and-menu {
+  margin-right: 10px;
+}
+
+.post-likes {
+  margin-right: 20px;
+  margin-bottom: 0;
+}
+
+.btn-post-show-menu {
+  margin-right: 40px;
+}

--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -25,7 +25,7 @@
             <h5 class="card-title bold-title" onclick="window.location='<%= admins_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
             
             <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
-            <div class="card-text post-body gray-content" onclick='window.location="<%= admins_post_path(id: post.id) %>"' title="<%= post.body %>">
+            <div class="card-text post-index-body gray-content" onclick='window.location="<%= admins_post_path(id: post.id) %>"' title="<%= post.body %>">
               <%= simple_format(sanitize(truncated_content, tags: [])) %>
             </div>
 

--- a/app/views/admins/posts/show.html.erb
+++ b/app/views/admins/posts/show.html.erb
@@ -1,32 +1,47 @@
 <% provide(:title,  "動画詳細") %>
 
-<div class="container">
+<div class="container post-show">
   <div class="row">
-<table class="table table-hover table-scroll">
-<thead>
-  <tr>
-    <th width="100">タイトル</th>
-    <th>内容</th>
-    <th>Youtube</th>
-    <th width="300" colspan="3"></th>
-  </tr>
-</thead>
+    <div class="video-container">
+      <iframe width="100%" height="0%" src="https://www.youtube.com/embed/<%= @post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
 
-<tbody>
-  <tr>
-    <td width="230"><%= @post.title %></td>
-    <td width="230"><%= simple_format(@post.body) %></td>
-    <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=@post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
-    <td>
-      <% if @post.admin_id == current_admin.id %>
-        <%= button_to '動画一覧', admins_posts_path, method: :get ,class: "btn btn-primary" %><br>
-        <%= button_to '編集画面', edit_admins_post_path(@post), method: :get ,class: "btn btn-success" %><br>
-        <%= button_to '削除', admins_post_path(@post), method: :delete, class: "btn btn-danger", data: { confirm: "#{@post.title}を削除してもよろしいですか？" } %>
-      <% else %>
-        <%= button_to '動画一覧', admins_posts_path, method: :get ,class: "btn btn-primary" %><br>
-      <% end %>
-    </td>
-  </tr>
-</table>
+    <div class="post-details">
+      <h2 class="post-title"><%= @post.title %></h2>
 
+      <div class="post-info" style="display: flex; justify-content: space-between; align-items: center;">
+        <div class="post-author">
+          <% if @post.admin_id.present? %>
+            <%= image_tag "admin.png", class: 'rounded-circle', size: '30x30' %>
+          <% else %>
+            <% image = @post.user.present? && @post.user.profile.present? && @post.user.profile.image.present? ? @post.user.profile.image : "user_default.png" %>
+            <%= image_tag image, class: 'rounded-circle', size: '30x30' %>
+          <% end %> 
+          <%= @post.admin ? @post.admin.name : @post.user.name %>
+        </div>
+
+        <div class="post-metadata" style="display: flex; align-items: center;">
+          <div class="post-likes" id="post_<%= @post.id %>">
+            <%= @post.decorate.formatted_likes(current_user) %>
+          </div>
+
+          <time class="timestamp" datetime="<%= @post.created_at.strftime('%Y-%m-%d') %>">
+            <%= @post.created_at.strftime('%Y-%m-%d') %>
+          </time>
+
+          <% if @post.admin_id == current_admin.id %>
+            <button class="btn btn-post-show-menu" data-bs-toggle="dropdown">︙</button>
+            <ul class="dropdown-menu">
+              <li><%= link_to '編集', edit_admins_post_path(id: @post.id), class: "nav-link" %></li>
+              <li><%= link_to '削除', admins_post_path(id: @post.id), method: :delete, data: { confirm: "選択した記事を削除します。" }, class: "nav-link" %></li>
+            </ul>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="post-body">
+        <%= @post.body %>
+      </div>     
+    </div>
+  </div>
 </div>

--- a/app/views/users/likes/_post_likes.html.erb
+++ b/app/views/users/likes/_post_likes.html.erb
@@ -1,9 +1,9 @@
 <% if current_user.post_already_liked?(@post.id) %>
   <%= link_to post_destroy_users_post_likes_path(@post), class:'text-decoration-none', method: :delete, remote: true do %>
-    <i class="fa-solid fa-heart ml-4 mr-2 mb-4"></i><%= @post.likes.count %>
+    <i class="fa-solid fa-heart ml-4 mr-2"></i><%= @post.likes.count %>
   <% end %>
 <% else %>
   <%= link_to post_create_users_post_likes_path(@post), class:'text-decoration-none', method: :post, remote: true do %>
-    <i class="fa-regular fa-heart ml-4 mr-2 mb-4"></i><%= @post.likes.count %>
+    <i class="fa-regular fa-heart ml-4 mr-2"></i><%= @post.likes.count %>
   <% end %>
 <% end %>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -26,7 +26,7 @@
             <h5 class="card-title bold-title" onclick="window.location='<%= users_post_path(id: post.id) %>'" title="<%= post.title %>"><%= truncated_title %></h5>
             
             <% truncated_content = truncate(post.body.gsub(/[\r\n]+/, ' '), length: 25, omission: '...') %>
-            <div class="card-text post-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
+            <div class="card-text post-index-body gray-content" onclick='window.location="<%= users_post_path(id: post.id) %>"' title="<%= post.body %>">
               <%= simple_format(sanitize(truncated_content, tags: [])) %>
             </div>
 
@@ -43,7 +43,7 @@
                 <time class="timestamp" datetime="<%= post.created_at.strftime('%Y-%m-%d') %>">
                   <%= post.created_at.strftime('%Y-%m-%d') %>
                 </time>
-                <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px; margin-left: 8px;">︙</button>
+                <button class="btn btn-menu" data-bs-toggle="dropdown" style="width: 30px;">︙</button>
                 <ul class="dropdown-menu">
                   <% if post.user_id == current_user.id %>
                     <li><%= link_to '閲覧', users_post_path(id: post.id), class: "nav-link" %></li>

--- a/app/views/users/posts/show.html.erb
+++ b/app/views/users/posts/show.html.erb
@@ -10,8 +10,12 @@
 
       <div class="post-info" style="display: flex; justify-content: space-between; align-items: center;">
         <div class="post-author">
-          <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
-          <%=image_tag image, class: 'rounded-circle', size: '40x40' %>
+          <% if @post.admin_id.present? %>
+            <%= image_tag "admin.png", class: 'rounded-circle', size: '30x30' %>
+          <% else %>
+            <% image = @post.user.present? && @post.user.profile.present? && @post.user.profile.image.present? ? @post.user.profile.image : "user_default.png" %>
+            <%= image_tag image, class: 'rounded-circle', size: '30x30' %>
+          <% end %> 
           <%= @post.admin ? @post.admin.name : @post.user.name %>
         </div>
 
@@ -24,15 +28,14 @@
             <%= @post.created_at.strftime('%Y-%m-%d') %>
           </time>
 
-          <button class="btn btn-post-show-menu" data-bs-toggle="dropdown">︙</button>
-          <ul class="dropdown-menu">
-            <% if @post.user_id == current_user.id %>
+          <% if @post.user_id == current_user.id %>
+            <button class="btn btn-post-show-menu" data-bs-toggle="dropdown">︙</button>
+            <ul class="dropdown-menu">
               <li><%= link_to '編集', edit_users_post_path(id: @post.id), class: "nav-link" %></li>
               <li><%= link_to '削除', users_post_path(id: @post.id), method: :delete, data: { confirm: "選択した記事を削除します。" }, class: "nav-link" %></li>
-            <% else %>
-              <li><%= link_to '閲覧', users_post_path(id: @post.id), class: "nav-link" %></li>
-            <% end %>
-          </ul>
+            </ul>
+          <% end %>
+
         </div>
       </div>
 

--- a/app/views/users/posts/show.html.erb
+++ b/app/views/users/posts/show.html.erb
@@ -1,104 +1,111 @@
-<% provide(:title,  "動画詳細") %>
-<div class="container">
+<% provide(:title, "動画詳細") %>
+<div class="container post-show">
   <div class="row">
-    <table class="table table-hover table-scroll">
-      <thead>
-        <tr>
-          <th width="100">タイトル</th>
-          <th>内容</th>
-          <th>Youtube</th>
-          <th width="300" colspan="3"></th>
-        </tr>
-      </thead>
+    <div class="video-container">
+      <iframe width="100%" height="0%" src="https://www.youtube.com/embed/<%= @post.youtube_url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
 
-      <tbody>
-        <tr>
-          <td width="230"><%= @post.title %></td>
-          <td width="230"><%= simple_format(@post.body) %></td>
-          <td><iframe width="600" height="315" src="https://www.youtube.com/embed/<%=@post.youtube_url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></td>
-          <td>
+    <div class="post-details">
+      <h2 class="post-title"><%= @post.title %></h2>
+
+      <div class="post-info" style="display: flex; justify-content: space-between; align-items: center;">
+        <div class="post-author">
+          <% image = current_user.profile.present? && current_user.profile.image.present? ? current_user.profile&.image : "user_default.png" %>
+          <%=image_tag image, class: 'rounded-circle', size: '40x40' %>
+          <%= @post.admin ? @post.admin.name : @post.user.name %>
+        </div>
+
+        <div class="post-metadata" style="display: flex; align-items: center;">
+          <div class="post-likes" id="post_<%= @post.id %>">
+            <%= render 'users/likes/post_likes', locals: { post: @post } %>
+          </div>
+
+          <time class="timestamp" datetime="<%= @post.created_at.strftime('%Y-%m-%d') %>">
+            <%= @post.created_at.strftime('%Y-%m-%d') %>
+          </time>
+
+          <button class="btn btn-post-show-menu" data-bs-toggle="dropdown">︙</button>
+          <ul class="dropdown-menu">
             <% if @post.user_id == current_user.id %>
-              <%= button_to '動画一覧', users_posts_path, method: :get ,class: "btn btn-primary" %><br>
-              <%= button_to '編集画面', edit_users_post_path(@post), method: :get ,class: "btn btn-success" %><br>
-              <%= button_to '削除', users_post_path(@post), method: :delete ,class: "btn btn-danger", data: {confirm: "#{@post.title}を削除してもよろしいですか？"} %>
+              <li><%= link_to '編集', edit_users_post_path(id: @post.id), class: "nav-link" %></li>
+              <li><%= link_to '削除', users_post_path(id: @post.id), method: :delete, data: { confirm: "選択した記事を削除します。" }, class: "nav-link" %></li>
             <% else %>
-              <%= button_to '動画一覧', users_posts_path, method: :get ,class: "btn btn-primary" %><br>
+              <li><%= link_to '閲覧', users_post_path(id: @post.id), class: "nav-link" %></li>
             <% end %>
-          </td>
-          <td>
-            <div id="post_<%= @post.id %>">
-              <%= render 'users/likes/post_likes', locals: { post: @post } %>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <!-- コメント欄 -->
-    <div class="post-comments-card mt-2">
-      <%= render "users/posts/comment_form_and_preview", dashboard: false %>
-      
-      <div class="post-comments-list">
-        <% if @post_comments.present? %>
-          <% @post_comments.each do |post_comment| %>
-            <!-- コメント編集Modal -->
-            <%= form_with model: [@post, post_comment], url: users_post_post_comment_path(@post, post_comment), method: :patch do |form| %>
-              <div class="modal fade" id="postCommentUpdateModal-<%=post_comment.id %>" tabindex="-1" aria-labelledby="postCommentUpdateModalLabel" aria-hidden="true">
-                <div class="modal-dialog">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h5 class="modal-title" id="postCommentUpdateModalLabel">コメントの編集</h5>
-                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                      <%= form.text_area :content, class:"form-control" %>
-                    </div>
-                    <div class="modal-footer">
-                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
-                      <%= form.submit "更新する", class: "btn btn-primary" %>
-                    </div>
+          </ul>
+        </div>
+      </div>
+
+      <div class="post-body">
+        <%= @post.body %>
+      </div>     
+    </div>
+  </div>
+
+  <!-- コメント欄 -->
+  <div class="post-comments-card mt-2">
+    <%= render "users/posts/comment_form_and_preview", dashboard: false %>
+    
+    <div class="post-comments-list">
+      <% if @post_comments.present? %>
+        <% @post_comments.each do |post_comment| %>
+          <!-- コメント編集Modal -->
+          <%= form_with model: [@post, post_comment], url: users_post_post_comment_path(@post, post_comment), method: :patch do |form| %>
+            <div class="modal fade" id="postCommentUpdateModal-<%=post_comment.id %>" tabindex="-1" aria-labelledby="postCommentUpdateModalLabel" aria-hidden="true">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title" id="postCommentUpdateModalLabel">コメントの編集</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                  </div>
+                  <div class="modal-body">
+                    <%= form.text_area :content, class:"form-control" %>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+                    <%= form.submit "更新する", class: "btn btn-primary" %>
                   </div>
                 </div>
-              </div>
-            <% end %>
-            <!-- コメント編集Modalここまで -->
-            <div class="post-comment-box">
-              <div class='post-comment-info d-flex align-items-center'> <%# 投稿者の名前、プロフィール写真、投稿日時 %>
-                <% image = post_comment.user.profile.present? && post_comment.user.profile.image.present? ? post_comment.user.profile&.image : "user_default.png" %>
-                <%=image_tag image, class: 'rounded-circle', size: '30x30' %>
-                <strong><%= post_comment.user.name %></strong>
-                <div class='post-comment-info-rightside d-flex align-items-center ms-auto'>
-                  <time><%= l(post_comment.created_at, format: :long) %></time>
-                  <div class="dropdown">
-                    <button class="btn" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">︙</button>
-                    <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-                      <% if post_comment.user == current_user %>
-                        <li>
-                          <!-- Button trigger modal -->
-                          <button type="button" class="btn dropdown-item" data-bs-toggle="modal" data-bs-target="#postCommentUpdateModal-<%=post_comment.id %>">編集</button>
-                          <!-- Button trigger modalここまで -->
-                        </li>
-                        <li>
-                          <%= link_to '削除', users_post_post_comment_path(@post, post_comment), method: :delete, data: { confirm: '削除してよろしいですか?' }, class: 'dropdown-item' %>
-                        </li>
-                      <% else %>
-                        <li>
-                          <%= link_to 'このコメントを報告する', '#', class: 'dropdown-item' %></li>
-                        <li>
-                      <% end %>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-              <div class='post-comment-content'>
-                <%= format_and_linkify_text(post_comment.content) %>
               </div>
             </div>
           <% end %>
-        <% else %>
-          <p class="has_no_comments">コメントがありません</p>
+          <!-- コメント編集Modalここまで -->
+          <div class="post-comment-box">
+            <div class='post-comment-info d-flex align-items-center'> <%# 投稿者の名前、プロフィール写真、投稿日時 %>
+              <% image = post_comment.user.profile.present? && post_comment.user.profile.image.present? ? post_comment.user.profile&.image : "user_default.png" %>
+              <%=image_tag image, class: 'rounded-circle', size: '30x30' %>
+              <strong><%= post_comment.user.name %></strong>
+              <div class='post-comment-info-rightside d-flex align-items-center ms-auto'>
+                <time><%= l(post_comment.created_at, format: :long) %></time>
+                <div class="dropdown">
+                  <button class="btn" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">︙</button>
+                  <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                    <% if post_comment.user == current_user %>
+                      <li>
+                        <!-- Button trigger modal -->
+                        <button type="button" class="btn dropdown-item" data-bs-toggle="modal" data-bs-target="#postCommentUpdateModal-<%=post_comment.id %>">編集</button>
+                        <!-- Button trigger modalここまで -->
+                      </li>
+                      <li>
+                        <%= link_to '削除', users_post_post_comment_path(@post, post_comment), method: :delete, data: { confirm: '削除してよろしいですか?' }, class: 'dropdown-item' %>
+                      </li>
+                    <% else %>
+                      <li>
+                        <%= link_to 'このコメントを報告する', '#', class: 'dropdown-item' %></li>
+                      <li>
+                    <% end %>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div class='post-comment-content'>
+              <%= format_and_linkify_text(post_comment.content) %>
+            </div>
+          </div>
         <% end %>
-      </div>
-
+      <% else %>
+        <p class="has_no_comments">コメントがありません</p>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**PR概要**
ユーザー、管理者ともに動画投稿詳細ページのレイアウトを修正しました。
それに伴い、動画投稿一覧のレイアウトの微修正も行っています。

仕様書
https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=1822374234

**実装内容**
ユーザー、管理者とも確認お願いします。

1. レイアウトをスクショのように変更しました。
2. 投稿者名の前にプロフィールのアイコンを表示しました。
3. 自分の投稿のページのみ、投稿日の右に三点リーダを表示し、その中に編集・削除メニューを追加しました。
4. 自分以外の投稿ページの際は三点リーダは表示されません。
5. 動画一覧へのボタンを削除しました。理由は、サイドメニューに動画一覧ボタンがあるためです。しかし、もしこの仕様だと不具合があるようでしたらボタンを復活させますので、遠慮なくご意見ください。

<img width="1449" alt="スクリーンショット 2023-12-31 17 38 10" src="https://github.com/nishinotakay/teac-output-new/assets/100989880/9996f43f-799d-4ff1-a100-bc750f86dbeb">
