### PR TITLE
管理者がログアウト後、一般ユーザーのログイン画面に遷移する現象を解消

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource)
     case resource
     when :user
-      root_path
+      new_user_session_path
     when :admin
       new_admin_session_path
     when :manager

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,17 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def after_sign_out_path_for(resource)
+    case resource
+    when :user
+      root_path
+    when :admin
+      new_admin_session_path
+    when :manager
+      root_path
+    end
+  end
+
   def configure_permitted_parameters
     added_attrs = %i[email name password password_confirmation]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs

--- a/app/views/layouts/admins/_header.html.erb
+++ b/app/views/layouts/admins/_header.html.erb
@@ -51,7 +51,11 @@
       <li style="padding-left:3px"><%= current_admin.name %></li>
       <hr style="height:0.5px">
       <li style="padding-left:3px"><%= link_to "詳細画面", admins_show_admins_users_path, method: :get %></li>
-      <li style="padding-left:3px"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
+      <% if current_user.present? %>
+        <li style="padding-left:3px"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
+      <% elsif current_admin.present? %>
+        <li style="padding-left:3px"><%= link_to "ログアウト", destroy_admin_session_path, method: :delete %></li>
+      <% end %>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION

▫️概要

管理者ユーザーがログアウト後、一般ユーザーのログイン画面に遷移してしまう
→ 管理者のログイン画面にリダイレクトするように修正

———-

◽️タスク・仕様書

https://trello.com/c/vXJGCjpa

https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit#gid=0

———-

◽️実装内容・手法

・deviseのメソッドをオーバーライドしてログアウト後、管理者ユーザーのログイン画面にリダイレクトさせる
・あわせて viewに記載されている ログアウト時のpathを修正

————

▫️確認事項

動作確認をお願いします。

手順

1.管理者ユーザーでログイン
2.管理者のダッシュボードにログイン後、ログアウトする
→ http://0.0.0.0:3000/admins/sign_in   にリダイレクトされることを確認する
