### PR TITLE
seedファイルの実行時、Uidはすでに存在しますのエラーの解消

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   validates :name,  presence: true, length: { in: 1..10 }
   validates :age,   allow_nil: true, numericality: { greater_than_or_equal_to: 10 }
   validates :profile, length: { maximum: 200 } # 追記
-  validates :uid, uniqueness: { scope: :provider }
+  validates :uid, uniqueness: { scope: :provider }, allow_nil: true
 
   enum gender: { male: 0, female: 1, other: 2 }
 


### PR DESCRIPTION
▫️概要

DBをリセット後、seedファイルをmigrateすると下記のエラーが発生する。
ActiveRecord::RecordInvalid: バリデーションに失敗しました: Uidはすでに存在しますのエラー

→ こちらの現象を解消する

———-

◽️タスク・仕様書

https://trello.com/c/gL7n6vyK

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=226598413

———-

◽️実装内容・手法

・validatesのオプションにallow_nil: trueを追加

→ seedファイルの実行時はuidにはnilしか格納されません。uidに値が入るタイミングは、「Googleでログイン」などでOAuth認証を実行した時のみです。seedファイル生成時は(uidにnilが入るタイミングは)、allow_nil: trueで検証をスキップ、uidに値が入ったときのみ同一のproviderのuidの一意性を検証するようにしています。

※ログを見ると、test_user0は生成できていますが、test_user1 生成時に「Uidはすでに存在します」のエラーが発生してしまいます。seed実行時に、test_user0のuidにnilが入り、test_user1の生成時にも、同様にuidに2つ目のnilが入ってしまい、nilという文字列がダブって、一意性の違反になっていると思われます(いろいろ調べましたが、seedファイル実行のタイミングでuidに入るのはnilだけので、他に被るものはないかと)。

————

▫️確認事項

※ データベースのリセット含むので、ご自身のタイミングで確認してください。
   特に緊急性が高いわけではないので、しばらく宙に浮かしていても問題ないと思います。

------

動作確認をお願いします。
下記のコマンドでseedファイルを実行して、下記のエラーが発生しないことを確認する。

ActiveRecord::RecordInvalid: バリデーションに失敗しました: Uidはすでに存在しますのエラー

手順

1. bin/docker/bundle/exec rails db:migrate:reset
2. bin/docker/bundle/exec rails db:migrate
3. bin/docker/bundle/exec rails db:seed
