### PR TITLE
記事のストック機能(あとで読む)を追加

### DIFF
--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -36,6 +36,8 @@ module Users
         format.html
         format.json { render json: @article }
       end
+
+      @stock = Stock.find_by(user_id: current_user.id, article_id: @article)
     end
 
     def new

--- a/app/controllers/users/stocks_controller.rb
+++ b/app/controllers/users/stocks_controller.rb
@@ -1,20 +1,29 @@
-class Users::StocksController < ApplicationController
+module Users
+  class Users::StocksController < Users::Base
+    before_action :set_article, only: %i[create destroy]
 
   def create
-    @article = Article.find(params[:article_id])
-    @stock = current_user.stocks.create(article_id: params[:article_id])
+    @stock = current_user.stocks.create(stock_params)
   end
 
   def destroy
-    @article = Article.find(params[:article_id])
-    @stock = Stock.find_by(
-      article_id: params[:article_id],
-      user_id: current_user.id
-    )
+    @stock = Stock.find_by(stock_params)
     @stock.destroy
   end
 
   def index
-    @stocks = Stock.where(user_id: current_user.id)
+    @stock_article = Stock.get_stock_article(current_user)
+  end
+
+  private
+
+  def set_article
+    @article = Article.find(params[:article_id])
+  end
+
+  def stock_params
+    params.permit(:article_id,:id)
+  end
+
   end
 end

--- a/app/controllers/users/stocks_controller.rb
+++ b/app/controllers/users/stocks_controller.rb
@@ -1,0 +1,20 @@
+class Users::StocksController < ApplicationController
+
+  def create
+    @article = Article.find(params[:article_id])
+    @stock = current_user.stocks.create(article_id: params[:article_id])
+  end
+
+  def destroy
+    @article = Article.find(params[:article_id])
+    @stock = Stock.find_by(
+      article_id: params[:article_id],
+      user_id: current_user.id
+    )
+    @stock.destroy
+  end
+
+  def index
+    @stocks = Stock.where(user_id: current_user.id)
+  end
+end

--- a/app/controllers/users/stocks_controller.rb
+++ b/app/controllers/users/stocks_controller.rb
@@ -13,6 +13,7 @@ module Users
 
   def index
     @stock_article = Stock.get_stock_article(current_user)
+    @stock_articles = Kaminari.paginate_array(@stock_article).page(params[:page]).per(30)
   end
 
   private

--- a/app/controllers/users/stocks_controller.rb
+++ b/app/controllers/users/stocks_controller.rb
@@ -12,8 +12,22 @@ module Users
   end
 
   def index
-    @stock_article = Stock.get_stock_article(current_user)
-    @stock_articles = Kaminari.paginate_array(@stock_article).page(params[:page]).per(30)
+    filter = {
+      author: params[:author],
+      title: params[:title],
+      subtitle: params[:subtitle],
+      content: params[:content],
+      start: params[:start],
+      finish: params[:finish],
+      order: params[:order] ||= 'DESC'
+    }
+
+    @stocks = Article.stock_paginated_and_sort_filter(filter,current_user).page(params[:page]).per(30)
+    respond_to do |format|
+      format.html
+      format.json { render json: @stocks }
+    end
+
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -9,6 +9,7 @@ class Article < ApplicationRecord
   belongs_to :user, optional: true
   has_many :article_comments, dependent: :destroy
   has_many :likes, dependent: :destroy
+  has_many :stocks, dependent: :destroy
 
   validates :title, presence: true, length: { in: 1..40 }
   validates :sub_title, allow_nil: true, length: { maximum: 50 }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -36,8 +36,7 @@ class Article < ApplicationRecord
     start = Time.zone.parse(filter[:start].presence || '2020-01-01').beginning_of_day
     finish = Time.zone.parse(filter[:finish].presence || Date.current.to_s).end_of_day
     
-    left_joins(:user, :admin)
-      .joins(:stocks)
+    left_joins(:user, :admin, :stocks)
       .includes(:admin, :user, :article_comments)
       .where(['title LIKE ? AND sub_title LIKE ? AND content LIKE ?',
               "%#{filter[:title]}%", "%#{filter[:subtitle]}%", "%#{filter[:content]}%"])

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -5,7 +5,4 @@ class Stock < ApplicationRecord
   validates :user_id, presence: true
   validates :article_id, presence: true
 
-  def self.get_stock_article(user)
-    self.where(user_id: user.id).map(&:article)
-  end
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -4,4 +4,8 @@ class Stock < ApplicationRecord
 
   validates :user_id, presence: true
   validates :article_id, presence: true
+
+  def self.get_stock_article(user)
+    self.where(user_id: user.id).map(&:article)
+  end
 end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,0 +1,7 @@
+class Stock < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+
+  validates :user_id, presence: true
+  validates :article_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   has_many :chat_rooms, through: :chat_room_users
   has_many :chat_messages
   has_many :post_comments, dependent: :destroy
+  has_many :stocks, dependent: :destroy
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,4 +85,8 @@ class User < ApplicationRecord
   def post_already_liked?(post_id)
     likes.where(post_id: post_id).exists?
   end
+
+  def stock?(article)
+    stocks.exists?(article_id: article.id)
+  end
 end

--- a/app/views/layouts/users/_header.html.erb
+++ b/app/views/layouts/users/_header.html.erb
@@ -66,6 +66,7 @@
           <li style="padding-left:3px"><%= current_user.name %></li>
           <hr style="height:0.5px">
           <li style="padding-left:3px"><%= link_to "詳細画面", users_user_path(current_user), method: :get, class: "d-block" %></li>
+          <li style="padding-left:3px"><%= link_to "ストック一覧", users_stocks_path, method: :get %></li>
           <li style="padding-left:3px"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
         <% end %>
       </ul>

--- a/app/views/users/articles/show.html.erb
+++ b/app/views/users/articles/show.html.erb
@@ -27,8 +27,12 @@
         <hr>
         <div class="m-4 article-content" data-article="<%= @article.sanitized_content %>"></div>
         <!-- いいね機能のボタン-->
-          <div id="article_<%= @article.id %>">
+          <div id="article_<%= @article.id %>" class="d-inline">
             <%= render 'users/likes/article_likes', locals: { article: @article } %>
+          </div>
+        <!-- ストック機能のボタン -->
+          <div id="article_stock_<%= @article.id %>" class="d-inline ml-3">
+            <%= render 'users/stocks/stock', locals: { article: @article, stock: @stock } %>
           </div>
       </div>  
       <div class="article-comments-card mt-2">

--- a/app/views/users/stocks/_stock.html.erb
+++ b/app/views/users/stocks/_stock.html.erb
@@ -1,0 +1,13 @@
+<% if current_user.stock?(@article) %>
+  <%= link_to users_article_stock_path(@article, @stock), method: :delete, remote: true do %>
+    <%= button_tag(class: "btn btn-dark") do %>
+      <i class="fas fa-folder-minus"></i>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= link_to users_article_stocks_path(@article), method: :post, remote: true do %>
+    <%= button_tag(class: "btn btn-outline-dark") do %>
+      <i class="fas fa-folder-plus"></i>
+     <% end %>
+  <% end %>
+<% end %>

--- a/app/views/users/stocks/_stock.html.erb
+++ b/app/views/users/stocks/_stock.html.erb
@@ -8,6 +8,6 @@
   <%= link_to users_stocks_path(article_id: @article), method: :post, remote: true do %>
     <%= button_tag(class: "btn btn-outline-dark") do %>
       <span class="pr-2"><i class="fas fa-folder-plus"></i></span><%= @article.stocks.count %>
-     <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/stocks/_stock.html.erb
+++ b/app/views/users/stocks/_stock.html.erb
@@ -1,13 +1,13 @@
 <% if current_user.stock?(@article) %>
   <%= link_to users_stock_path(article_id: @article, id:@stock), method: :delete, remote: true do %>
     <%= button_tag(class: "btn btn-dark") do %>
-      <i class="fas fa-folder-minus"></i>
+      <span class="pr-2"><i class="fas fa-folder-minus"></i></span><%= @article.stocks.count %>
     <% end %>
   <% end %>
 <% else %>
   <%= link_to users_stocks_path(article_id: @article), method: :post, remote: true do %>
     <%= button_tag(class: "btn btn-outline-dark") do %>
-      <i class="fas fa-folder-plus"></i>
+      <span class="pr-2"><i class="fas fa-folder-plus"></i></span><%= @article.stocks.count %>
      <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/stocks/_stock.html.erb
+++ b/app/views/users/stocks/_stock.html.erb
@@ -1,11 +1,11 @@
 <% if current_user.stock?(@article) %>
-  <%= link_to users_article_stock_path(@article, @stock), method: :delete, remote: true do %>
+  <%= link_to users_stock_path(article_id: @article, id:@stock), method: :delete, remote: true do %>
     <%= button_tag(class: "btn btn-dark") do %>
       <i class="fas fa-folder-minus"></i>
     <% end %>
   <% end %>
 <% else %>
-  <%= link_to users_article_stocks_path(@article), method: :post, remote: true do %>
+  <%= link_to users_stocks_path(article_id: @article), method: :post, remote: true do %>
     <%= button_tag(class: "btn btn-outline-dark") do %>
       <i class="fas fa-folder-plus"></i>
      <% end %>

--- a/app/views/users/stocks/create.js.erb
+++ b/app/views/users/stocks/create.js.erb
@@ -1,0 +1,1 @@
+$("#article_stock_<%= @article.id %>").html("<%= escape_javascript(render partial: 'users/stocks/stock', locals: { post: @article, stock: @stock }) %>");

--- a/app/views/users/stocks/create.js.erb
+++ b/app/views/users/stocks/create.js.erb
@@ -1,1 +1,1 @@
-$("#article_stock_<%= @article.id %>").html("<%= escape_javascript(render partial: 'users/stocks/stock', locals: { post: @article, stock: @stock }) %>");
+$("#article_stock_<%= @article.id %>").html("<%= escape_javascript(render partial: 'users/stocks/stock', locals: { post: @article }) %>");

--- a/app/views/users/stocks/destroy.js.erb
+++ b/app/views/users/stocks/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#article_stock_<%= @article.id %>").html("<%= escape_javascript(render partial: 'users/stocks/stock', locals: { post: @article, stock: @stock }) %>");

--- a/app/views/users/stocks/index.html.erb
+++ b/app/views/users/stocks/index.html.erb
@@ -29,7 +29,7 @@
                 <tr>
                   <td class="link-td" id="article-title">
                     <div class="d-flex align-items-center">
-                      <%= link_to article.title,users_article_path(article.id), class: 'text-decoration-none text-secondary' %>
+                      <%= link_to article.title,users_article_path(article.id), class: 'text-decoration-none text-secondary', data: { turbolinks: false } %>
                         <% if article.likes.present? %>
                           <% if current_user.article_already_liked?(article.id) %>
                             <i class="fa-solid fa-heart ml-4 mr-2"></i><%= article.likes.count %>
@@ -42,7 +42,7 @@
                       <% end %>
                     </div>
                   </td>
-                  <td class="link-td" id="article-subtitle"><%= link_to article.sub_title, users_article_path(article.id), class: 'text-decoration-none text-secondary' %></td>
+                  <td class="link-td" id="article-subtitle"><%= link_to article.sub_title, users_article_path(article.id), class: 'text-decoration-none text-secondary', data: { turbolinks: false } %></td>
                   <% if article.admin.present? %>
                     <td class="link-td" id="article-authur"><%= article.admin.name %></td>
                   <% else %>

--- a/app/views/users/stocks/index.html.erb
+++ b/app/views/users/stocks/index.html.erb
@@ -25,7 +25,7 @@
             </tr>
           </thead>
           <tbody>
-              <% @stock_article.each do |article| %>
+              <% @stocks.each do |article| %>
                 <tr>
                   <td class="link-td" id="article-title">
                     <div class="d-flex align-items-center">
@@ -55,7 +55,7 @@
           </tbody>
         </table>
         <div class="article-paginate">
-          <%= paginate @stock_articles, theme: 'bootstrap-5' %>
+          <%= paginate @stocks, theme: 'bootstrap-5' %>
         </div>
       </div>
     </div>

--- a/app/views/users/stocks/index.html.erb
+++ b/app/views/users/stocks/index.html.erb
@@ -1,3 +1,13 @@
+<%= javascript_pack_tag "users/index_articles_and_dashboards" %>
+<button type="button" class="btn btn-success sort-modal-btn ml-5" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
+  並べ替え
+</button>
+<button type="button" class="btn btn-success filter-modal-btn ml-3" data-bs-toggle="modal" data-bs-target="#sortFilterModal" style="display: none;">
+  絞り込み検索
+</button>
+<% if params[:reset] %>
+  <button type="button" class="btn btn-outline-success reset-btn ml-3">リセット</button>
+<% end %>
 <% provide(:title, "ストックした記事一覧") %>
 
 <div class="content">
@@ -46,6 +56,74 @@
         </table>
         <div class="article-paginate">
           <%= paginate @stock_articles, theme: 'bootstrap-5' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="sortFilterModal" tabindex="-1" aria-labelledby="sortFilterModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="form-inline">
+        <h5 class="modal-title text-center flex-grow-1 mt-4" id="sortFilterModalLabel"></h5>
+        <button type="button" class="modal-close btn-close mr-3" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-right">
+        <div class="sort-modal" style="display: none;">
+          <div class="form-group row my-5">
+            <label for="sort-select" class="col-sm-3 col-form-label"><%= Article.human_attribute_name(:created_at) %></label>
+            <div class="col-md-9">
+              <% order = {'DESC': '新しい順', 'ASC': '古い順'} %>
+              <% params[:order] ||= 'DESC' %>
+              <select id="sort-select" class="form-select" aria-label="Default select desc">
+                <option value="<%= params[:order] %>" selected><%= order.delete(:"#{params[:order]}") %></option>
+                <option value="<%= order.keys[0] %>"><%= order[order.keys[0]] %></option>
+              </select>
+            </div>
+          </div>
+        </div>    
+        <div class="filter-modal" style="display: none;">
+          <div class="form-group row my-4">
+            <label for="input-author" class="col-sm-4 col-form-label"><%= Article.human_attribute_name(:user) %></label>
+            <div class="col-md-8">
+              <input type="text" aria-label="author" id="input-author" class="form-control" value="<%= params[:author] %>">
+            </div>
+          </div>
+          <div class="form-group row my-4">
+            <label for="input-title" class="col-sm-4 col-form-label"><%= Article.human_attribute_name(:title) %></label>
+            <div class="col-md-8">
+              <input type="text" aria-label="title" id="input-title" class="form-control" value="<%= params[:title] %>">
+            </div>
+          </div>
+          <div class="form-group row my-4">
+            <label for="input-subtitle" class="col-sm-4 col-form-label"><%= Article.human_attribute_name(:sub_title) %></label>
+            <div class="col-md-8">
+              <input type="text" aria-label="subtitle" id="input-subtitle" class="form-control" value="<%= params[:subtitle] %>">
+            </div>
+          </div>
+          <div class="form-group row my-4">
+            <label for="input-content" class="col-sm-4 col-form-label"><%= Article.human_attribute_name(:content) %></label>
+            <div class="col-md-8">
+              <input type="text" aria-label="content" id="input-content" class="form-control" value="<%= params[:content] %>">
+            </div>
+          </div>
+          <div class="form-group row my-4">
+            <label for="input-created" class="col-sm-3 col-form-label"><%= Article.human_attribute_name(:created_at) %></label>
+            <div class="col-md-9 form-inline">
+              <div class="col-md-5">
+                <input type="date" aria-label="created" id="input-start" class="form-control" value="<%= params[:start] %>">
+              </div>
+              <div class="offset-1 align-bottom">〜</div>
+              <div class="col-md-5">
+                <input type="date" aria-label="created" id="input-finish" class="form-control" value="<%= params[:finish] %>">
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="text-center">
+          <button type="button" class="btn btn-primary submit-btn"></button>
+          <button type="button" class="modal-close btn btn-secondary" data-bs-dismiss="modal">戻る</button>
         </div>
       </div>
     </div>

--- a/app/views/users/stocks/index.html.erb
+++ b/app/views/users/stocks/index.html.erb
@@ -43,6 +43,9 @@
               <% end %>
           </tbody>
         </table>
+        <div class="article-paginate">
+          <%= paginate @stock_articles, theme: 'bootstrap-5' %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/users/stocks/index.html.erb
+++ b/app/views/users/stocks/index.html.erb
@@ -1,0 +1,49 @@
+<% provide(:title, "ストックした記事一覧") %>
+
+<div class="content">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+        <table class="table articles-table table-scroll">
+          <thead>
+            <tr>
+              <th class="px-5"><%= Article.human_attribute_name(:title) %></th>
+              <th class="px-5"><%= Article.human_attribute_name(:sub_title) %></th>
+              <th class="px-5"><%= Article.human_attribute_name(:user) %></th>
+              <th class="px-5"><%= Article.human_attribute_name(:created_at) %></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+              <% @stock_article.each do |article| %>
+                <tr>
+                  <td class="link-td" id="article-title">
+                    <div class="d-flex align-items-center">
+                      <%= link_to article.title,users_article_path(article.id), class: 'text-decoration-none text-secondary' %>
+                        <% if article.likes.present? %>
+                          <% if current_user.article_already_liked?(article.id) %>
+                            <i class="fa-solid fa-heart ml-4 mr-2"></i><%= article.likes.count %>
+                          <% else %>
+                            <i class="fa-regular fa-heart ml-4 mr-2"></i><%= article.likes.count %>
+                          <% end %>
+                        <% end %>
+                      <%if article.article_comments.present? %>
+                        <i class="fa-regular fa-comment fa-sm ms-auto">&nbsp<%= article.article_comments.count %></i>
+                      <% end %>
+                    </div>
+                  </td>
+                  <td class="link-td" id="article-subtitle"><%= link_to article.sub_title, users_article_path(article.id), class: 'text-decoration-none text-secondary' %></td>
+                  <% if article.admin.present? %>
+                    <td class="link-td" id="article-authur"><%= article.admin.name %></td>
+                  <% end %>
+                  <td class="link-td" id="article-authur"><%= article.user.name %></td>
+                  <td class="link-td" id="article-createdat"><%= l(article.created_at, format: :long) %></td>
+                  <td></td>
+                </tr>
+              <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/stocks/index.html.erb
+++ b/app/views/users/stocks/index.html.erb
@@ -35,8 +35,9 @@
                   <td class="link-td" id="article-subtitle"><%= link_to article.sub_title, users_article_path(article.id), class: 'text-decoration-none text-secondary' %></td>
                   <% if article.admin.present? %>
                     <td class="link-td" id="article-authur"><%= article.admin.name %></td>
-                  <% end %>
-                  <td class="link-td" id="article-authur"><%= article.user.name %></td>
+                  <% else %>
+                    <td class="link-td" id="article-authur"><%= article.user.name %></td>
+                  <% end %>  
                   <td class="link-td" id="article-createdat"><%= l(article.created_at, format: :long) %></td>
                   <td></td>
                 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     resources :chat_rooms, only: [:create, :show]
     resources :articles do
       resources :article_comments, only: %i[create destroy update] # 記事コメント機能
+      resources :stocks, only:[:create, :destroy, :index]
       resource :likes, only: [] do
         post 'article_create', on: :member
         delete 'article_destroy', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,9 +51,9 @@ Rails.application.routes.draw do
   namespace :users do
     resources :dash_boards, only: [:index]
     resources :chat_rooms, only: [:create, :show]
+    resources :stocks, only:[:create, :destroy, :index]
     resources :articles do
       resources :article_comments, only: %i[create destroy update] # 記事コメント機能
-      resources :stocks, only:[:create, :destroy, :index]
       resource :likes, only: [] do
         post 'article_create', on: :member
         delete 'article_destroy', on: :member

--- a/db/migrate/20240113113625_create_stocks.rb
+++ b/db/migrate/20240113113625_create_stocks.rb
@@ -1,0 +1,11 @@
+class CreateStocks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :stocks do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :article, foreign_key: true, null: false
+
+      t.timestamps
+      t.index [:user_id, :article_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_11_042545) do
+ActiveRecord::Schema.define(version: 2024_01_13_113625) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -198,6 +198,16 @@ ActiveRecord::Schema.define(version: 2024_01_11_042545) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "stocks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_stocks_on_article_id"
+    t.index ["user_id", "article_id"], name: "index_stocks_on_user_id_and_article_id", unique: true
+    t.index ["user_id"], name: "index_stocks_on_user_id"
+  end
+
   create_table "tenants", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 20, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -273,6 +283,8 @@ ActiveRecord::Schema.define(version: 2024_01_11_042545) do
   add_foreign_key "posts", "admins"
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"
+  add_foreign_key "stocks", "articles"
+  add_foreign_key "stocks", "users"
   add_foreign_key "tweet_comments", "tweets"
   add_foreign_key "tweet_comments", "users"
   add_foreign_key "tweets", "users"


### PR DESCRIPTION
———

▫️概要

記事のストック機能(あとで読む)を追加

———-

◽️タスク・仕様書

https://trello.com/c/vN8YuJVY

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=737342304

———-

◽️実装内容・手法

![ストックされていない画像](https://github.com/nishinotakay/teac-output-new/assets/111734087/f640d3f1-4f19-4010-853d-a24b435f770a)


・記事詳細ページにQuitaのようなストックボタンを表示
→ ボタンを押した記事は、ストックした記事一覧で確認することができる
　並び替えや絞り込み検索も あわせて実装しました
————

▫️確認事項

マイグレーションファイルがあるので、
rails db:migrate 実行後、下記の手順で動作確認をお願いします。

手順:

1.一般ユーザーでログイン
2.記事一覧をクリックして、任意の記事をクリックして記事詳細ページに遷移する
3.ストックボタン( いいねボタン の隣にあります ) をクリックして、ストックする
4.ページ右上のユーザーアイコン画像をクリックして、ストック一覧をクリック
5.ストックした記事が ストックした記事一覧に表示されていることを確認する
6.記事タイトルもしくはサブタイトルをクリックして、記事詳細ページに遷移することを確認する
