### PR TITLE
N＋1 問題の解消。記事投稿一覧および動画投稿一覧

### DIFF
--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -19,7 +19,7 @@ module Users
         order:    params[:order] ||= 'DESC'
       }
   
-      @articles = Article.paginated_and_sort_filter(filter).includes(:likes).page(params[:page]).per(30)
+      @articles = Article.includes(:likes).paginated_and_sort_filter(filter).page(params[:page]).per(30)
 
       respond_to do |format|
         format.html

--- a/app/controllers/users/articles_controller.rb
+++ b/app/controllers/users/articles_controller.rb
@@ -19,7 +19,7 @@ module Users
         order:    params[:order] ||= 'DESC'
       }
   
-      @articles = Article.paginated_and_sort_filter(filter).page(params[:page]).per(30)
+      @articles = Article.paginated_and_sort_filter(filter).includes(:likes).page(params[:page]).per(30)
 
       respond_to do |format|
         format.html

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -6,7 +6,7 @@ module Users
     skip_before_action :authenticate_user!, only: %i[show], if: :admin_signed_in?
 
     def index
-      @posts = Post.filtered_and_ordered_posts(params, params[:page], 30)
+      @posts = Post.includes(:likes,:post_comments).filtered_and_ordered_posts(params, params[:page], 30)
 
       respond_to do |format|
         format.html


### PR DESCRIPTION
▫️概要

n+1問題の解消_記事一覧,動画投稿一覧など

———-

◽️タスク・仕様書

https://trello.com/c/Jldb5npK

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=754333106

———-

◽️実装内容・手法

・includesメソッドで関連付けされたlikesテーブルとpost_commentsテーブルのレコードを一度に取得

————

▫️確認事項

記事一覧と動画投稿一覧ページの読み込み時のN+1問題が解消されたか、確認をお願いします。

手順:

1. 一般ユーザーでログイン
2. 記事一覧および動画投稿一覧ページをクリック
3. VS codeのログを確認。
4. 記事ごとにロードされている likeテーブルのレコードが最小限のロードで行われていることを確認する。

下記にn+1問題が発生しているログと解消後のログを例として転載しております。
解消後のログになっていれば、N+1問題の解消になっているかと存じます。

------

**記事一覧のログ**

**▲解消前**

 app/views/users/articles/shared/_articles_table.html.erb:38
  Like Load (5.2ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`article_id` = 173
  ↳ app/views/users/articles/shared/_articles_table.html.erb:38
  Like Load (4.3ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`article_id` = 172
  ↳ app/views/users/articles/shared/_articles_table.html.erb:38
  Like Load (6.0ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`article_id` = 172
  ↳ app/views/users/articles/shared/_articles_table.html.erb:38
  Like Load (4.9ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`article_id` = 171

**▲解消後**

SELECT `likes`.* FROM `likes` WHERE `likes`.`article_id` IN (180, 179, 178, 177, 176, 175, 174, 173, 172, 171, 170, 169, 168, 167, 166, 165, 164, 163, 162, 161, 160, 159, 158, 157, 156, 155, 154, 153, 152, 151)

-------

**動画投稿一覧のログ**

**解消前**

like

docker-rails-service  |   ↳ app/views/users/posts/index.html.erb:20
docker-rails-service  |   Like Load (1.5ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`post_id` = 35
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:5:in `formatted_likes'
docker-rails-service  |   PostComment Load (3.3ms)  SELECT `post_comments`.* FROM `post_comments` WHERE `post_comments`.`post_id` = 35
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:23:in `formatted_comment_count'
docker-rails-service  |   Like Load (0.9ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`post_id` = 34
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:5:in `formatted_likes'
docker-rails-service  |   PostComment Load (0.5ms)  SELECT `post_comments`.* FROM `post_comments` WHERE `post_comments`.`post_id` = 34
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:23:in `formatted_comment_count'


post_comments

docker-rails-service  |   PostComment Load (1.4ms)  SELECT `post_comments`.* FROM `post_comments` WHERE `post_comments`.`post_id` = 35
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:23:in `formatted_comment_count'
docker-rails-service  |   PostComment Load (0.6ms)  SELECT `post_comments`.* FROM `post_comments` WHERE `post_comments`.`post_id` = 34
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:23:in `formatted_comment_count'
docker-rails-service  |   PostComment Load (0.9ms)  SELECT `post_comments`.* FROM `post_comments` WHERE `post_comments`.`post_id` = 33
docker-rails-service  |   ↳ app/decorators/post_decorator.rb:23:in `formatted_comment_count'

-------

**解消後**

in 句にidが入る。

like

docker-rails-service  |   ↳ app/views/users/posts/index.html.erb:20
docker-rails-service  |   Like Load (1.1ms)  SELECT `likes`.* FROM `likes` WHERE `likes`.`post_id` IN (35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6)

PostComment 

docker-rails-service  |   ↳ app/decorators/post_decorator.rb:23:in `formatted_comment_count'
docker-rails-service  |   PostComment Load (0.9ms)  SELECT `post_comments`.* FROM `post_comments` WHERE `post_comments`.`post_id` IN (35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 39, 36, 37, 38, 40)