### PR TITLE
package.jsonの警告を一つ消す。

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack": "^4.19.1",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^4.11.1"
   }


### PR DESCRIPTION
[概要]
PR概要を記述する

package.jsonの警告を一つ消す。

タスク
 [x]なし
 []あり (タスクのリンクがあれば貼る)
実装内容・手法
実装内容や、問題の解決手法を記述する

before
docker起動時に出る警告のうち、比較的すぐ治せるものを修正した。(webpackをわざと4.46.1にしてエラーを吐かせています。わかりやすくしています。)
<img width="1378" alt="スクリーンショット 2024-03-21 0 07 53" src="https://github.com/nishinotakay/teac-output-new/assets/107759288/5b57c99e-aff3-49a5-a92b-0c27015c7536">

after
警告が一つ消える。
<img width="704" alt="スクリーンショット 2024-03-21 0 13 00" src="https://github.com/nishinotakay/teac-output-new/assets/107759288/840ecba9-9188-4bb3-b628-c80c16743542">
実装画像などあれば添付する
ちなみに、adminLTE3系とbootstrap5系は互換性がないです。ですので、bootstrapが外れる問題が起こっていませんか？これは別文脈で考えたいと思います。

![スクリーンショット 2024-03-21 1 31 39](https://github.com/nishinotakay/teac-output-new/assets/107759288/1034bcfd-cac8-4879-9489-28c67364ebd7)


<img width="1383" alt="スクリーンショット 2024-03-21 0 11 36" src="https://github.com/nishinotakay/teac-output-new/assets/107759288/af5a9f1e-c556-49bd-8a4a-b6ca129e5ad4">


