### PR TITLE
<code>タグでQiitaのような色付きのコードブロックのプレビューを作成

### DIFF
--- a/app/javascript/packs/users/articles.js
+++ b/app/javascript/packs/users/articles.js
@@ -4,6 +4,7 @@ import { marked } from 'marked'
 import '../../stylesheets/users/articles'
 
 marked.setOptions({
+  breaks: true,
   highlight: function (code, lang) {
     if(lang && lang.indexOf(":") >= 0){
       lang = lang.split(":")[0]


### PR DESCRIPTION
<span style="font-size: 200%">

▫️概要

記事投稿で、HTMLの<code>タグを使用して、Qiitaのようにコードブロックに色を付けるプレビューを作成

———-

◽️タスク・仕様書

https://trello.com/c/wt7NQU2w

https://docs.google.com/spreadsheets/d/1ojlvXXtMDB97LAq7ZHd55I_FTE65pthfmoDjda-vJeQ/edit#gid=754333106

———-

◽️実装内容・手法

・marked.jsのオプションで改行を有効にする。

→改行を有効にしないと \```ファイル名 (ruby:test.rb) \```と入力して Enterを押しても、改行が反映されていませんでした。
その結果、テキストとして入力されてしまい、Pタグが生成されてしまっていました(コードブロックが崩壊していた)。
pタグではなく、codeタグが生成されるようになりhighlight.jsが反映されて、コードに色が付きました。

https://github.com/nishinotakay/teac-output-new/assets/111734087/64d58501-3040-4238-b0fb-4fe7c6fcc944

------

▫️補足事項

・markdownにおけるコードブロックの書き方(Quitaから引っ張ってきました)

\```ruby:title.rb
 puts 'code block.'
\```

----

下記の手順で動作確認をお願いします。
コードブロック(黒い背景色)とコードの随所に色が付けば問題ないかと思います。

手順:

１.エディターの欄に\```ruby:test.rb \```と入力
２.コードブロック(黒い背景色)が表示されるので、任意でコードを書く
３.コードにQuitaのように色を付くことを確認する
</span>