### PR TITLE
つぶやきコメントの削除アラート日本語化

### DIFF
--- a/app/views/users/tweets/show.html.erb
+++ b/app/views/users/tweets/show.html.erb
@@ -76,7 +76,7 @@
                       編集</button>
                     </li>
                     <li>
-                      <%= link_to '削除', users_tweet_tweet_comment_path(@tweet, comment), method: :delete, data: { confirm: 'Are you sure?' }, class:"dropdown-item" %>
+                      <%= link_to '削除', users_tweet_tweet_comment_path(@tweet, comment), method: :delete, data: { confirm: t('tweet.confirmations.delete_comment') }, class:"dropdown-item" %>
                     </li>
                   <% end %>
                 </ul>

--- a/config/locales/ja_tweet.yml
+++ b/config/locales/ja_tweet.yml
@@ -9,4 +9,6 @@ ja:
         updated_at: '編集日時'
         author: '投稿者'
         images: '画像'
-
+  tweet:
+    confirmations:
+      delete_comment: "本当にコメントを削除しますか？"


### PR DESCRIPTION
概要
一般ユーザーログインからつぶやきコメント詳細ページでコメントを削除する際に表示されるアラートを日本語化。

【修正ファイル】
　・ app/views/users/tweets/show.html.erb
　・config/locales/ja_tweet.yml