### PR TITLE
管理者側編集、削除機能の削除及びユーザー側の編集ページレイアウト修正

### DIFF
--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -9,26 +9,6 @@ module Admins
       today = Date.today.strftime('%Y%m%d').to_i
     end
 
-    # def edit
-    # end
-
-    # def update
-    #   if @user.update(users_params)
-    #     redirect_to admins_users_path, notice: 'ユーザー情報の更新が完了しました'
-    #   else
-    #     render :edit
-    #   end
-    # end
-
-    # def destroy
-    #   if @user.destroy
-    #     flash[:success] = "#{@user.name}のデータを削除しました。"
-    #     redirect_to admins_users_path
-    #   else
-    #     render :index
-    #   end
-    # end
-
     def index
       order = { 
         id: params[:ord_id], 

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -9,25 +9,25 @@ module Admins
       today = Date.today.strftime('%Y%m%d').to_i
     end
 
-    def edit
-    end
+    # def edit
+    # end
 
-    def update
-      if @user.update(users_params)
-        redirect_to admins_users_path, notice: 'ユーザー情報の更新が完了しました'
-      else
-        render :edit
-      end
-    end
+    # def update
+    #   if @user.update(users_params)
+    #     redirect_to admins_users_path, notice: 'ユーザー情報の更新が完了しました'
+    #   else
+    #     render :edit
+    #   end
+    # end
 
-    def destroy
-      if @user.destroy
-        flash[:success] = "#{@user.name}のデータを削除しました。"
-        redirect_to admins_users_path
-      else
-        render :index
-      end
-    end
+    # def destroy
+    #   if @user.destroy
+    #     flash[:success] = "#{@user.name}のデータを削除しました。"
+    #     redirect_to admins_users_path
+    #   else
+    #     render :index
+    #   end
+    # end
 
     def index
       order = { 

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -35,8 +35,8 @@
                   <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                   <ul class="dropdown-menu">
                     <li><%= link_to '詳細', admins_user_path(user.id), class:"nav-link" %></li>
-                    <li><%= link_to '編集', edit_admins_user_path(user.id), class:"nav-link" %></li>
-                    <li><%= link_to '削除', admins_user_path(user.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li>
+                    <!-- <li><%= link_to '編集', edit_admins_user_path(user.id), class:"nav-link" %></li> -->
+                    <!-- <li><%= link_to '削除', admins_user_path(user.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li> -->
                   </ul>
                 </td>
               </tr>

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -35,8 +35,6 @@
                   <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                   <ul class="dropdown-menu">
                     <li><%= link_to '詳細', admins_user_path(user.id), class:"nav-link" %></li>
-                    <!-- <li><%= link_to '編集', edit_admins_user_path(user.id), class:"nav-link" %></li> -->
-                    <!-- <li><%= link_to '削除', admins_user_path(user.id), method: :delete, data: { confirm: 'Are you sure?' }, class:"nav-link" %></li> -->
                   </ul>
                 </td>
               </tr>

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -1,79 +1,81 @@
 <%= javascript_pack_tag "users/profiles" %>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 
-<div class="offset-3 div-title-form">
-  <div class="card card-outline card-primary">
-    <div class="card-header text-center">
-      <h2>プロフィールを編集する</h2>
+<div class="container">
+  <div class="offset-3 div-title-form mx-auto" style="max-width: 600px;">
+    <div class="card card-outline card-primary">
+      <div class="card-header text-center">
+        <h2>プロフィール編集する</h2>
+      </div>
+      <br>
+      <%= form_with model: @profile, url: users_profile_path, local: true do |f| %>
+        <%= render 'layouts/error_messages', model: f.object %>
+        <div class="text-center">
+          <% image = @profile.present? && @profile.image.present? ? @profile.image : "user_default.png" %>
+          <%= image_tag image , class: "rounded-circle", size: "120x120" %>
+        </div>
+        <div style="padding-left:50px">
+          <div class="form-group">
+            <div class="form-inline">
+              <i class="fas fa-image"></i>
+              <label class="profile-indent">プロフィール画像</label>
+              <label class="profile-indent-image">
+                <%= f.file_field :image %>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="form-inline">
+              <i class="fas fa-user"></i>
+              <label class="profile-indent">名前</label>
+              <label class="profile-indent-gender">
+                <%= f.fields_for :user do |user_fields| %>
+                  <%= user_fields.text_field :name, class: "form-control", style: "width:300px" %>
+                <% end %>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="form-inline">
+              <i class="fas fa-gift"></i>
+              <label class="profile-indent">誕生日</label>
+              <label class="profile-indent-birthday">
+                <%= f.date_field :birthday, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="form-inline">
+              <i class="fas fa-heart"></i>
+              <label class="profile-indent">性別</label>
+              <label class="profile-indent-gender">
+                <%= f.select :gender, Profile.genders_i18n.keys.map {|k| [Profile.genders_i18n[k], k]}, {include_blank: '選択してください'}, class: 'form-control', style: "width:300px" %>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="form-inline">
+              <i class="fas fa-book-open"></i>
+              <label class="profile-indent">登録日</label>
+              <label class="profile-indent-input">
+                <%= f.date_field :registration_date, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
+              </label>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="form-inline">
+              <i class="fas fa-flag"></i>
+              <label class="profile-indent">趣味</label>
+              <label class="profile-indent-hobby">
+                <%= f.text_area :hobby, class: "form-control", style: "width:300px" %>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="text-center form-group">
+          <%= f.submit "更新", class: "btn btn-primary" , style: "width:150px" %>
+        </div>
+      <% end %>
     </div>
-    <br>
-    <%= form_with model: @profile, url: users_profile_path, local: true do |f| %>
-      <%= render 'layouts/error_messages', model: f.object %>
-      <div class="text-center">
-        <% image = @profile.present? && @profile.image.present? ? @profile.image : "user_default.png" %>
-        <%= image_tag image , class: "rounded-circle", size: "120x120" %>
-      </div>
-      <div style="padding-left:50px">
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-image"></i>
-            <label class="profile-indent">プロフィール画像</label>
-            <label class="profile-indent-image">
-              <%= f.file_field :image %>
-            </label>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-user"></i>
-            <label class="profile-indent">名前</label>
-            <label class="profile-indent-gender">
-              <%= f.fields_for :user do |user_fields| %>
-                <%= user_fields.text_field :name, class: "form-control", style: "width:300px" %>
-              <% end %>
-            </label>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-gift"></i>
-            <label class="profile-indent">誕生日</label>
-            <label class="profile-indent-birthday">
-              <%= f.date_field :birthday, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
-            </label>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-heart"></i>
-            <label class="profile-indent">性別</label>
-            <label class="profile-indent-gender">
-              <%= f.select :gender, Profile.genders_i18n.keys.map {|k| [Profile.genders_i18n[k], k]}, {include_blank: '選択してください'}, class: 'form-control', style: "width:300px" %>
-            </label>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-book-open"></i>
-            <label class="profile-indent">登録日</label>
-            <label class="profile-indent-input">
-              <%= f.date_field :registration_date, use_month_numbers: true , class: 'form-control', style: "width:300px" %>
-            </label>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="form-inline">
-            <i class="fas fa-flag"></i>
-            <label class="profile-indent">趣味</label>
-            <label class="profile-indent-hobby">
-              <%= f.text_area :hobby, class: "form-control", style: "width:300px" %>
-            </label>
-          </div>
-        </div>
-      </div>
-      <div class="text-center form-group">
-        <%= f.submit "更新", class: "btn btn-primary" , style: "width:150px" %>
-      </div>
-    <% end %>
   </div>
 </div>


### PR DESCRIPTION
【概要】
　・管理者側の登録ユーザー一覧ページより、三点リーダーの編集、削除機能を無くす。
　　"閲覧"表示は"詳細"に変更。
　・ユーザー側のプロフィール一覧ページのcurrent_user三点リーダー編集ページのレイアウト調整。
　　レイアウトは中央揃いに修正。
　・不要となった関連ファイルの削除。
　　controllers/admins/users_controller.rb内のアクション内（edit,update,destroy）のコメントアウト。
　　views/admins/users/index.html.erb内の編集、削除リンクをコメントアウト。
　　views/admins/users/edit.html.erbファイルの削除。
　　
【仕様書】
　・管理者画面の登録者一覧画面部分で一部修正。
　　https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit?　　gid=1920388814#gid=1920388814
【その他】
　仕様書についてですが既存の内容に対して編集、削除の不要という表記にしておりますが、美観を整えるために
　必要の無い添付画像を削除しても問題なければお知らせください。対応致します。
　　