### PR TITLE
不要なrender 'layouts/error_messagesの行を削除

### DIFF
--- a/app/views/users/tweets/_new.html.erb
+++ b/app/views/users/tweets/_new.html.erb
@@ -13,7 +13,6 @@
         <div class="container-fluid">
           <div class="row form-group">
             <%= form_with(model: @tweet, url: users_tweets_path, method: :post, local: true) do |form| %>
-              <%= render 'layouts/error_messages', model: form.object %>
               <div style="text-align:center;">
                 <div class="field">
                   <%= form.file_field :images, accept: 'image/png, image/jpeg, image/gif', multiple: true, class: "form-control" %>


### PR DESCRIPTION
【概要】
　一般ユーザーでのログインでつぶやき投稿する際、モーダルが展開しなくなった。
【原因】
　_error_messages.html.erbファイルを削除したにも関わらずレンダリングする記述が残っていた。
【実装内容・手法】
　app/views/users/tweets/_new.html.erbファイル16行目に   
　<%= render 'layouts/error_messages', model: form.object %>の記述が残っていた為、
　これを削除することにより問題解決することができた。

