### PR TITLE
つぶやき投稿数を表示させる

### DIFF
--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -15,7 +15,8 @@ module Admins
         name: params[:ord_name], 
         email: params[:ord_email], 
         articles: params[:ord_articles],
-        posts: params[:ord_posts] 
+        posts: params[:ord_posts], 
+        tweets: params[:ord_tweets]
       }.compact
 
       filter = {
@@ -24,7 +25,9 @@ module Admins
         articles_min: params[:flt_articles_min], 
         articles_max: params[:flt_articles_max],
         posts_min: params[:flt_posts_min], 
-        posts_max: params[:flt_posts_max]
+        posts_max: params[:flt_posts_max],
+        tweets_min: params[:flt_tweets_min], 
+        tweets_max: params[:flt_tweets_max]
       }
 
       @users = if order.count == 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,17 +41,21 @@ class User < ApplicationRecord
     artcl_max = filter[:articles_max].blank? ? Article.count : filter[:articles_max]
     posts_min = filter[:posts_min].blank? ? 0 : filter[:posts_min]
     posts_max = filter[:posts_max].blank? ? Post.count : filter[:posts_max]
-
+    tweets_min = filter[:tweets_min].blank? ? 0 : filter[:tweets_min]
+    tweets_max = filter[:tweets_max].blank? ? Tweet.count : filter[:tweets_max]
+  
     users = where(["name like ? and email like ?", "%#{filter[:name]}%", "%#{filter[:email]}%"])
-      .left_joins(:articles).left_joins(:posts).group("users.id")
+      .left_joins(:articles).left_joins(:posts).left_joins(:tweets).group("users.id")
       .having("count(articles.id) between ? and ?", artcl_min, artcl_max)
       .having("count(posts.id) between ? and ?", posts_min, posts_max)
-    if order[0] == :articles || order[0] == :posts || order[0] == :profiles
+      .having("count(tweets.id) between ? and ?", tweets_min, tweets_max)
+    
+    if order[0] == :articles || order[0] == :posts || order[0] == :tweets
       users.order("COUNT(#{order[0].to_s}.id) #{order[1]}")
     else
       users.order(order[0] => order[1])
     end
-  end
+  end  
 
   def social_profile(provider)
     social_profiles.select { |sp| sp.provider == provider.to_s }.first

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -20,6 +20,7 @@
             <th>email</th>
             <th>記事投稿数</th>
             <th>動画投稿数</th>
+            <th>つぶやき投稿数</th>
             <th></th>
           </tr>
         </thead>
@@ -31,6 +32,7 @@
                 <td><%= user.email %></td>
                 <td><%= user.articles.count %></td>
                 <td><%= user.posts.count %></td>
+                <td><%= user.tweets.count %></td>
                 <td>
                   <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                   <ul class="dropdown-menu">


### PR DESCRIPTION
【概要】
　管理者側で登録ユーザー一覧につぶやき投稿数を表示させる。
【仕様書】
　https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit?
gid=587340562#gid=587340562
【Tellro】
　https://trello.com/c/IRE5ZNyR/235-%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E7%99%BB%E9%8C%B2%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E4%B8%80%E8%A6%A7%E3%81%A4%E3%81%B6%E3%82%84%E3%81%8D%E6%95%B0%E3%81%AE%E8%BF%BD%E5%8A%A0
【実装内容・手法】
　既に記事投稿数、動画投稿数のロジックが確立されている為、下記の３つのファイルを修正し、つぶやき投稿数も
　表示されるように同一の流れでコードを追加修正。
　・app/controllers/admins/users_controller.rb
　・app/models/user.rb
　・app/views/admins/users/index.html.erb