### PR TITLE
つぶやき一覧に遷移させるためのリンク機能を追加

### DIFF
--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -32,7 +32,7 @@
                 <td><%= user.email %></td>
                 <td><%= user.articles.count %></td>
                 <td><%= user.posts.count %></td>
-                <td><%= user.tweets.count %></td>
+                <td><%= link_to user.tweets.count, index_user_users_tweet_path(id: user.id), style: "text-decoration: none;" %></td>
                 <td>
                   <button class="btn" data-bs-toggle="dropdown" style="width: 66.5px" >︙</button>
                   <ul class="dropdown-menu">


### PR DESCRIPTION
【概要】
　管理者画面での登録ユーザー一覧ページのつぶやき投稿数から一覧ページへ遷移できる機能を追加
【仕様書】
　https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit?gid=815288679#gid=815288679
【Trelloのリンク】
　https://trello.com/c/Tithfdnx/415-%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E7%99%BB%E9%8C%B2%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E4%B8%80%E8%A6%A7%E3%81%A4%E3%81%B6%E3%82%84%E3%81%8D%E6%95%B0%E3%81%AE%E3%83%AA%E3%83%B3%E3%82%AF%E3%81%8B%E3%82%89%E3%81%A4%E3%81%B6%E3%82%84%E3%81%8D%E4%B8%80%E8%A6%A7%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AB%E9%81%B7%E7%A7%BB
【実装内容・手法】
　追加・修正したファイルは１つのみ⇩
　元々あるapp/views/admins/users/index.html.erbファイルのつぶやき投稿数カウント部分にリンクを追加し、指定した
　ユーザーのつぶやき投稿数一覧に遷移できるようにパスを指定。
　キーはユーザーIDで取得し、指定したユーザーに飛ばす。
　その他：デフォルトのリンク設定では数字に下線が入る為、レイアウトの美観を考えて下線は削除するコードで書く。
　　　　　style: "text-decoration: none;"を記述。