### PR TITLE
記事投稿一覧への遷移機能

### DIFF
--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -30,7 +30,7 @@
               <tr>
                 <td><%= user.name %></td>
                 <td><%= user.email %></td>
-                <td><%= user.articles.count %></td>
+                <td><%= link_to user.articles.count, users_dash_boards_path(user_id: user.id), style: "text-decoration: none;" %></td>
                 <td><%= link_to user.posts.count, index_user_users_user_posts_path(user.id), style: "text-decoration: none;" %></td>
                 <td><%= link_to user.tweets.count, index_user_users_tweet_path(id: user.id), style: "text-decoration: none;" %></td>
                 <td>


### PR DESCRIPTION
【概要】
　記事投稿数にリンクを追加し、記事投稿一覧ページへ遷移できる機能を追加。
【仕様書】
　https://docs.google.com/spreadsheets/d/11AWBG5VwWw5xrv0Fc_TAYBxQ4wbvGchMehzSHj-z3jw/edit?gid=1940490183#gid=1940490183
【Trelloリンク】
https://trello.com/c/S1qaSrZE/416-%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E7%99%BB%E9%8C%B2%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E4%B8%80%E8%A6%A7%E8%A8%98%E4%BA%8B%E6%8A%95%E7%A8%BF%E6%95%B0%E3%81%AE%E3%83%AA%E3%83%B3%E3%82%AF%E3%81%8B%E3%82%89%E8%A8%98%E4%BA%8B%E6%8A%95%E7%A8%BF%E4%B8%80%E8%A6%A7%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AB%E9%81%B7%E7%A7%BB%E3%81%99%E3%82%8B#
【実装内容・手法】
　つぶやき投稿数と同じ手法で実装。
　修正ファイルは１つのみ
　app/views/admins/users/index.html.erbファイル内の記事投稿数にリンク機能を追加し、パスを一覧ページに遷移できる
　ように修正。