### PR TITLE
ログインせずにつぶやき詳細にアクセスしたらNoMethodError

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -15,7 +15,13 @@ module Users
 
     def show
       @tweet_comments = @tweet.tweet_comments.order(created_at: :desc)
-      @tweet_comment = current_user.tweet_comments.new unless current_admin.present?
+      if current_user.present?
+        @tweet_comment = current_user.tweet_comments.new
+      elsif current_admin.present?
+        @tweet_comment = nil
+      else
+        redirect_to root_path
+      end
     end
 
     def new


### PR DESCRIPTION
▫️概要

ログインしていないユーザーが記事詳細画面にアクセスするとNoMethodErrorが発生(添付動画)。
→ 本来であればログインページにリダイレクトされるが、NoMethodErrorが発生。

![リダイレクトされずにエラーが発生 (1)](https://github.com/user-attachments/assets/b8ddcc4c-9dd0-4c32-aecf-50ce789a5756)

https://github.com/user-attachments/assets/7968ae66-3a38-43ec-9651-2173d719bede

———-

◽️タスク・仕様書

[https://trello.com/c/yplOO6lC](https://trello.com/c/mQSUyXbN)

———-

◽️実装内容・手法

単純に条件分岐を追記して解決。

current_userが存在する場合は、@tweet_commentsのインスタンスを生成。
current_userが存在しない場合、ログインページにリダイレクトさせる。

※ エラーが発生していた原因は skip_before_action :authenticate_user!, only: %i[show], if: :admin_signed_in?と思われます。管理者ページから一般ユーザーのつぶやき詳細をログインせずに閲覧する機能を追加しましたが、この際にcurrent_userのログインの有無をチェックしていなかったことが原因と思われます。

----

▫️確認手順

1. http://0.0.0.0:3000/users/sign_in にアクセス
2. ブラウザのurl欄に http://0.0.0.0:3000/users/tweets/1 などつぶやき詳細ページのurlを直接入力
→ ログインページにリダイレクトされることを確認する

・動作確認の動画

https://github.com/user-attachments/assets/174e5b52-6f21-415e-b1c0-d3ee1f99cb27

---

▫️捕捉事項

※ @tweet_comment = current_user.tweet_comments.newは、
   showページのコメント投稿機能のform_withでセットされている空のインスタンス。

※ 管理者は詳細画面でコメントすると必要がないので、 管理者がshowページにアクセスした場合は  @tweet_comment = nil でコメント機能を無効化。もともと 管理者がログインをスキップする機能は、一般側の管理のためであって、管理者は一般側のやりとりに参加しないため。

※ エラーが発生していた原因は skip_before_action :authenticate_user!, only: %i[show], if: :admin_signed_in?と思われる。管理者でログイン > 登録ユーザー詳細画面 > 投稿つぶやき から 一般ユーザーのつぶやき詳細をログインせずに閲覧する処理。この処理とバッティングしたので、 if else でcurrent_userのログイン時の処理と 非ログイン時の処理を条件分岐で明示的にしました(ログインしていないならリダイレクトさせる)

※RSpecのテストコードで不具合を発見しました。
このエラーが解消しないとテストがパスしないので確認をお願いします。

--------

▫️動作確認の動画

修正後、リダイレクトされるかの確認。

https://github.com/user-attachments/assets/174e5b52-6f21-415e-b1c0-d3ee1f99cb27

▫️修正の影響がないかの確認動画

・一般ユーザー側で問題なくコメントできるかの確認。

https://github.com/user-attachments/assets/6a98301d-932e-46dc-bcea-34b907290c41

・管理者 から　一般ユーザーのつぶやきページに遷移できるかの確認。

https://github.com/user-attachments/assets/3b22877b-4244-4767-be7c-208ce29567b7

