### PR TITLE
エラーメッセージを表示するパーシャルを復元

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -33,9 +33,6 @@ module Users
     end
 
     def edit
-      respond_to do |format|
-        format.js
-      end
     end
 
     def update
@@ -43,7 +40,8 @@ module Users
         flash[:success] = '編集成功しました。'
         redirect_to users_tweets_url
       else
-        render :edit
+        flash[:error] = @tweet.errors.full_messages.join('・')
+        redirect_to users_tweets_url
       end
     end
 

--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -40,8 +40,9 @@ module Users
         flash[:success] = '編集成功しました。'
         redirect_to users_tweets_url
       else
-        flash[:error] = @tweet.errors.full_messages.join('・')
-        redirect_to users_tweets_url
+        respond_to do |format|
+          format.js { render 'edit.js.erb' }
+        end
       end
     end
 

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,18 @@
+<% if model.errors.any? %>
+  <div class="alert alert-warning alert-dismissible">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    </ul>
+  </div>
+<% end %>
+<script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
+<script>
+$(function() {
+  $(".close").on('click', function() {
+    $(".alert").hide();
+  });
+});
+</script>

--- a/app/views/users/tweets/_edit.html.erb
+++ b/app/views/users/tweets/_edit.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="modal-body">
       <div class="row">
-        <%= form_with(model: @tweet, url: users_tweet_path, method: :patch, local: true) do |form| %>
+        <%= form_with(model: @tweet, url: users_tweet_path, method: :patch, local: false) do |form| %>
           <%= render 'layouts/error_messages', model: form.object %>
           <div style="text-align:center;"> 
             <div class="field">
@@ -25,3 +25,4 @@
     </div>
   </div>
 </div>          
+  

--- a/app/views/users/tweets/_edit.html.erb
+++ b/app/views/users/tweets/_edit.html.erb
@@ -10,12 +10,10 @@
     <div class="modal-body">
       <div class="row">
         <%= form_with(model: @tweet, url: users_tweet_path, method: :patch, local: false) do |form| %>
-          <%= render 'layouts/error_messages', model: form.object %>
+         <%= render 'layouts/error_messages', model: form.object %>
           <div style="text-align:center;"> 
-            <div class="field">
               <%= form.label :post, "#{yield(:label_text)}", class: "tweet-form" %><br>
-              <%= form.text_area :post, class: "form-control", id:"tweet_post", size: "50x5" %>
-            </div>
+              <%= form.text_area :post, class: "form-control", id:"tweet_post", rows: 5, style: "min-height: 100px;" %>
             <div class="actions">
               <br><%= form.submit "#{yield(:btn_text)}", class: "btn btn-lg btn-primary" %>
             </div>

--- a/app/views/users/tweets/edit.js.erb
+++ b/app/views/users/tweets/edit.js.erb
@@ -1,2 +1,5 @@
 $("#edit").html("<%= j render partial: 'users/tweets/edit', locals: { tweet: @tweet } %>");
 $("#edit").modal("show");
+
+$("#edit-modal .modal-content").html("<%= j render 'users/tweets/edit', tweet: @tweet %>");
+$("#edit-modal").modal("show");

--- a/app/views/users/tweets/edit.js.erb
+++ b/app/views/users/tweets/edit.js.erb
@@ -1,2 +1,2 @@
-$("#edit").html("<%= escape_javascript(render 'users/tweets/edit') %>");
+$("#edit").html("<%= j render partial: 'users/tweets/edit', locals: { tweet: @tweet } %>");
 $("#edit").modal("show");


### PR DESCRIPTION
▫️概要

つぶやき機能の編集ボタンをクリックしてもモーダルが開かない
「テンプレートが見つからない」というエラー。
→ ActionView::Template::Error (Missing partial layouts/_error_messages)

https://github.com/user-attachments/assets/050d6a07-d44b-4c6a-80da-555b37fbdf5e

———-

◽️タスク・仕様書

https://trello.com/c/B7DMk2Gm

———-

◽️実装内容・手法

「パーシャルが見つからない」というエラーなので、
削除された下記ののパーシャルをそのまま復元。

docker-rails-service  | ActionView::Template::Error (Missing partial layouts/_error_messages with {:locale=>[:ja], :formats=>[:js, :html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}. Searched in:
docker-rails-service  | app/views/users/tweets/_edit.html.erb:13
docker-rails-service  | app/views/users/tweets/_edit.html.erb:12
docker-rails-service  | app/views/users/tweets/edit.js.erb:1
docker-rails-service  | Started GET "/users/tweets" for 192.168.65.1 at 2024-09-12 11:04:47 +0000
docker-rails-service  | Cannot render console from 192.168.65.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1

![スクリーンショット 2024-09-12 20 17 44](https://github.com/user-attachments/assets/64e6de8a-557f-4210-960b-fa3219f8a73b)

————

▫️補足事項

RSpecのテストコードで不具合を発見しました。
このエラーが解消しないとテストがパスしないので確認をお願いします。

・修正後の動作確認の動画

https://github.com/user-attachments/assets/3947a1be-26ec-4e4a-95f9-227f8f505a3a

