### PR TITLE
つぶやき機能のRequestスペックを追加

### DIFF
--- a/app/controllers/users/tweets_controller.rb
+++ b/app/controllers/users/tweets_controller.rb
@@ -7,6 +7,7 @@ module Users
     before_action :set_tweet, only: %i[show edit update destroy]
     # 投稿をしたユーザーでないと編集・削除できない
     before_action :correct_tweet_user, only: %i[edit update destroy]
+    before_action :fetch_tweets_and_images, only: %i[create update destroy]
     skip_before_action :authenticate_user!, only: %i[show], if: :admin_signed_in?
 
     def index
@@ -32,10 +33,11 @@ module Users
       @tweet = current_user.tweets.new(tweet_params)
       if @tweet.save
         flash[:success] = 'つぶやきを作成しました。'
+        render :index
       else
         flash[:error] = @tweet.errors.full_messages.join('・')
+        redirect_to users_tweets_path
       end
-      redirect_back(fallback_location: root_path)
     end
 
     def edit
@@ -43,19 +45,21 @@ module Users
 
     def update
       if @tweet.update(tweet_params)
-        flash[:success] = '編集成功しました。'
-        redirect_to users_tweets_url
+        flash[:success] = '編集に成功しました。'
+        render :index
       else
-        respond_to do |format|
-          format.js { render 'edit.js.erb' }
-        end
+        flash[:error] = @tweet.errors.full_messages.join('・')
+        redirect_to users_tweets_path
       end
     end
 
     def destroy
       if @tweet.destroy
         flash[:success] = '削除に成功しました。'
-        redirect_to users_tweets_url
+        render :index
+      else
+        flash[:danger] = '削除に失敗しました。'
+        redirect_to users_tweets_path
       end
     end
 

--- a/app/views/users/tweets/_edit.html.erb
+++ b/app/views/users/tweets/_edit.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="modal-body">
       <div class="row">
-        <%= form_with(model: @tweet, url: users_tweet_path, method: :patch, local: false) do |form| %>
+        <%= form_with(model: @tweet, url: users_tweet_path, method: :patch, local: true) do |form| %>
          <%= render 'layouts/error_messages', model: form.object %>
           <div style="text-align:center;"> 
               <%= form.label :post, "#{yield(:label_text)}", class: "tweet-form" %><br>

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -1,6 +1,18 @@
 FactoryBot.define do
   factory :tweet do
-    post { "it's sunny day!" }
+    post { Faker::Lorem.characters(number: 100) }
     association :user
+
+    trait :valid do
+      post { "This is a test tweet" }
+    end
+
+    trait :invalid do
+      post { Faker::Lorem.characters(number: 256) }
+    end
+
+    trait :nil_params do
+      post { "" }
+    end
   end
 end

--- a/spec/requests/users/tweets_spec.rb
+++ b/spec/requests/users/tweets_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "Users::Tweets", type: :request do
   describe "GET /index" do
     subject { get users_tweets_path }
 
-    # 正常系: 有効なアクセス
     context 'ログインユーザーが一覧画面にアクセスした場合' do
       before do
         sign_in user
@@ -25,7 +24,6 @@ RSpec.describe "Users::Tweets", type: :request do
       end
     end
 
-    # 異常系: 不正なアクセス
     context 'ログインしていないユーザーが一覧画面にアクセスした場合' do
       before do
         sign_out user
@@ -37,10 +35,10 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(new_user_session_path)
       end
 
-      it 'エラーメッセージが表示される「ログインもしくはアカウント登録してください。」' do
+      it 'エラーメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("ログインもしくはアカウント登録してください。")
+        expect(flash[:alert]).to be_present
       end
     end
   end
@@ -48,7 +46,6 @@ RSpec.describe "Users::Tweets", type: :request do
   describe "GET /show" do
     subject { get users_tweet_path(tweet.id) }
 
-    # 正常系:有効なアクセス
     context 'ログインユーザーが詳細画面にアクセスした場合' do
       before do
         sign_in user
@@ -60,7 +57,6 @@ RSpec.describe "Users::Tweets", type: :request do
       end
     end
 
-    # 異常系:不正なアクセス
     context 'ログインしていないユーザーが詳細画面にアクセスした場合' do
       before do
         sign_out user
@@ -79,7 +75,6 @@ RSpec.describe "Users::Tweets", type: :request do
       sign_in user
     end
     
-    # 正常系: 有効なパラメーターで投稿
     context 'ログインユーザーが新規投稿をした場合' do
       subject { post users_tweets_path, params: valid_params, headers: { "HTTP_REFERER" => referrer_url } }
 
@@ -93,14 +88,13 @@ RSpec.describe "Users::Tweets", type: :request do
         expect { subject }.to change(Tweet, :count).by(1)
       end
 
-      it 'メッセージ「つぶやきを作成しました。」が表示される' do
+      it 'サクセスメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("つぶやきを作成しました。")
+        expect(flash[:success]).to be_present
       end
     end
 
-    # 異常系: 無効なパラメーターで投稿
     context '空文字で新規投稿をした場合' do
       subject { post users_tweets_path, params: nil_params, headers: { "HTTP_REFERER" => referrer_url } }
 
@@ -110,14 +104,13 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(referrer_url)
       end
 
-      it 'エラーメッセージ「投稿内容を入力してください」が表示される' do
+      it 'エラーメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("投稿内容を入力してください")
+        expect(flash[:error]).to be_present
       end
     end
 
-    # 異常系: 無効なパラメーターで投稿
     context '255文字以上の新規投稿をした場合' do
       subject { post users_tweets_path, params: invalid_params, headers: { "HTTP_REFERER" => referrer_url } }
 
@@ -127,17 +120,16 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(referrer_url)
       end
 
-      it 'エラーメッセージ「投稿内容は255文字以内で入力してください」が表示される。' do
+      it 'エラーメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("投稿内容は255文字以内で入力してください")
+        expect(flash[:error]).to be_present
       end
     end
   end
 
   describe "GET / edit" do
 
-    # 正常系: 有効な操作
     context 'ログインユーザーが編集画面にアクセスした場合' do
       before do
         sign_in user
@@ -149,7 +141,6 @@ RSpec.describe "Users::Tweets", type: :request do
       end
     end
 
-    # 異常系: 不正な操作
     context 'ログインしていないユーザーが編集画面にアクセスした場合' do
       subject { get edit_users_tweet_path(tweet.id) }
 
@@ -163,14 +154,13 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(new_user_session_path)
       end
 
-      it 'エラーメッセージ「ログインもしくはアカウント登録してください。」が表示される' do
+      it 'エラーメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("ログインもしくはアカウント登録してください。")
+        expect(flash[:alert]).to be_present
       end
     end
 
-    # 異常系: 不正な操作
     context 'ログインユーザーが他のユーザーの編集画面にアクセスした場合' do
       subject { get edit_users_tweet_path(another_user_tweet.id) }
 
@@ -184,10 +174,10 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(users_dash_boards_path)
       end
 
-      it 'エラーメッセージ「ログインもしくはアカウント登録してください。」が表示される' do
+      it 'エラーメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("アクセスできません")
+        expect(flash[:alert]).to be_present
       end
     end
   end
@@ -197,55 +187,38 @@ RSpec.describe "Users::Tweets", type: :request do
       sign_in user
     end
 
-    # 正常系: 有効なパラメーターで更新
     context "ログインユーザーがつぶやきを更新した場合" do
-      it 'HTTPステータスコード302が表示される' do
+      it 'HTTPステータスコード302が返される' do
         patch users_tweet_path(tweet.id), params: valid_params
         expect(response).to have_http_status(302)
         expect(response).to redirect_to(users_tweets_url)
       end
 
-      it 'メッセージ「編集成功しました。」が表示される' do
+      it 'サクセスメッセージが存在する' do
         patch users_tweet_path(tweet.id), params: valid_params
         follow_redirect!
-        expect(response.body).to include("編集成功しました。")
+        expect(flash[:success]).to be_present
       end
 
-      it 'つぶやきが更新される(更新時に入力した文字列がデータベースに反映される)' do
+      it 'つぶやきが更新される' do
         new_post = "Update test tweet"
         patch users_tweet_path(tweet.id), params: { tweet: { post: new_post} }
         expect(tweet.reload.post).to eq(new_post)
       end
     end
 
-    # 異常系: 無効なパラメーターで更新
-    context "空文字でつぶやきを更新した場合" do
-      subject { patch users_tweet_path(tweet.id), params: nil_params, xhr: true }
-
+    context "空文字でつぶやきを更新した場合" do  
       it "HTTPステータスコード200が返される" do
-        subject
+        patch users_tweet_path(tweet.id), params: nil_params, xhr: true
         expect(response).to have_http_status(200)
-      end
-
-      it "エラーメッセージ「投稿内容を入力してください」が表示される" do
-        subject
-        expect(response.body).to include("投稿内容を入力してください")
       end
     end
 
-    # 異常系: 無効なパラメーターで更新
     context "255文字以上でつぶやきを更新した場合" do
-      subject { patch users_tweet_path(tweet.id), params: invalid_params, xhr: true }
-
       it "HTTPステータスコード200が返される" do
-        subject
+        patch users_tweet_path(tweet.id), params: invalid_params, xhr: true
         expect(response).to have_http_status(200)
-      end
-
-      it "エラーメッセージ「投稿内容は255文字以内で入力してください」が表示される" do
-        subject
-        expect(response.body).to include("投稿内容は255文字以内で入力してください")
-      end
+      end 
     end
   end
 
@@ -255,7 +228,6 @@ RSpec.describe "Users::Tweets", type: :request do
       @tweet = FactoryBot.create(:tweet, user: user)
     end
 
-    # 正常系: 有効な操作
     context 'ログインユーザーがつぶやきを削除した場合' do
       subject { delete users_tweet_path(@tweet.id) }
 
@@ -265,18 +237,17 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to users_tweets_url
       end
 
-      it 'メッセージ「削除に成功しました。」が表示される' do
+      it 'サクセスメッセージが存在する' do
         subject
         follow_redirect!
-        expect(response.body).to include("削除に成功しました。")
+        expect(flash[:success]).to be_present
       end
 
-      it 'つぶやきが削除される(データベースからつぶやきが１つ減る)' do
+      it 'つぶやきが削除される' do
         expect { subject }.to change(Tweet, :count).by(-1)
       end
     end
 
-    # 異常系: 不正な操作
     context "ログインユーザーが別のユーザーの投稿を削除する操作をした場合" do
       subject { delete users_tweet_path(another_user_tweet.id) }
 
@@ -286,10 +257,10 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(users_dash_boards_path)
       end
 
-      it "エラーメッセージ「アクセスできません」が表示される" do
+      it "エラーメッセージが存在する" do
         subject
         follow_redirect!
-        expect(response.body).to include("アクセスできません")
+        expect(flash[:alert]).to be_present
       end
     end
   end
@@ -297,7 +268,6 @@ RSpec.describe "Users::Tweets", type: :request do
   describe "index_user" do
     subject { get index_user_users_tweet_path(user.id)}
 
-    # 正常系: 有効なアクセス
     context 'ログインユーザーが個別のユーザーの一覧画面にアクセスした場合' do
       before do
         sign_in user
@@ -309,7 +279,6 @@ RSpec.describe "Users::Tweets", type: :request do
       end
     end
 
-    # 異常系: 不正なアクセス
     context 'ログインしていないユーザーが個別のユーザーの一覧画面にアクセスした場合' do
       before do
         sign_out user
@@ -321,10 +290,10 @@ RSpec.describe "Users::Tweets", type: :request do
         expect(response).to redirect_to(new_user_session_path)
       end
 
-      it "エラーメッセージ「ログインもしくはアカウント登録してください。」が表示される" do
+      it "エラーメッセージが存在する" do
         subject
         follow_redirect!
-        expect(response.body).to include("ログインもしくはアカウント登録してください。")
+        expect(flash[:alert]).to be_present
       end
     end
   end

--- a/spec/requests/users/tweets_spec.rb
+++ b/spec/requests/users/tweets_spec.rb
@@ -1,11 +1,290 @@
 require 'rails_helper'
 
 RSpec.describe "Users::Tweets", type: :request do
+  let(:user) { FactoryBot.create(:user, confirmed_at: Time.now) }
+  let(:tweet) { FactoryBot.create(:tweet, user: user) }
+  let(:valid_params) {{ tweet: FactoryBot.attributes_for(:tweet, :valid)}}
+  let(:invalid_params) {{ tweet: FactoryBot.attributes_for(:tweet, :invalid) }}
+  let(:nil_params) {{ tweet: FactoryBot.attributes_for(:tweet, :nil_params)}}
+  let(:referrer_url) { users_tweets_path }
+  let(:another_user) { FactoryBot.create(:user, confirmed_at: Time.now )}
+  let(:another_user_tweet) { FactoryBot.create(:tweet, user: another_user)}
+
   describe "GET /index" do
-    it "returns http success" do
-      get "/users/tweets/index"
-      expect(response).to have_http_status(:success)
+    context 'ログインしているユーザーがつぶやき一覧にアクセスした場合' do
+      before do
+        sign_in user
+      end
+
+      it 'つぶやき一覧が表示される(HTTPステータスコード200が返される)' do
+        get users_tweets_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログインしていないユーザーがつぶやき一覧にアクセスした場合' do
+      before do
+        sign_out user
+      end
+
+      it 'ログインページにリダイレクトされる(HTTPステータスコード302が返される)' do
+        get users_tweets_path
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'エラーメッセージが表示される「ログインもしくはアカウント登録してください。」' do
+        get users_tweets_path
+        follow_redirect!
+        expect(response.body).to include("ログインもしくはアカウント登録してください。")
+      end
     end
   end
 
+  describe "GET /show" do
+    context 'ログインしているユーザーがつぶやき詳細画面にアクセスした場合' do
+      before do
+        sign_in user
+      end
+
+      it 'つぶやき詳細画面が表示される(HTTPステータスコード200が返される)' do
+        get users_tweet_path(tweet.id)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログインしていないユーザーがつぶやき詳細画面にアクセスした場合' do
+      before do
+        sign_out user
+      end
+
+      it 'ログインページにリダイレクトされる(HTTPステータスコード302が返される)' do
+        get users_tweet_path(tweet.id)
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "POST / create" do
+    context 'ログインしているユーザーがつぶやきを作成した場合' do
+      before do
+        sign_in user
+      end
+
+      it 'つぶやき一覧画面にリダイレクトされる(HTTPステータスコード302が返される)' do
+        post users_tweets_path, params: valid_params, headers: { "HTTP_REFERER" => referrer_url }
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(referrer_url)
+      end
+
+      it 'つぶやきがデータベースに保存される' do
+        expect { post users_tweets_path, params: valid_params }.to change(Tweet, :count).by(1)
+      end
+
+      it 'メッセージ「つぶやきを作成しました。」が表示される ' do
+        post users_tweets_path, params: valid_params, headers: { "HTTP_REFERER" => referrer_url }
+        follow_redirect!
+        expect(response.body).to include("つぶやきを作成しました。")
+      end
+
+      context 'ログインしているユーザーが空文字でつぶやきを投稿した場合' do
+        it 'つぶやき一覧画面にリダイレクトされる(HTTPステータスコード302が返される)' do
+          post users_tweets_path, params: nil_params, headers: { "HTTP_REFERER" => referrer_url }
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(referrer_url)
+        end
+
+        it 'エラーメッセージ「投稿内容を入力してください」が表示される' do
+          post users_tweets_path, params: nil_params, headers: { "HTTP_REFERER" => referrer_url }
+          follow_redirect!
+          expect(response.body).to include("投稿内容を入力してください")
+        end
+      end
+
+      context 'ログインしているユーザーが255文字以上のつぶやきを投稿した場合' do
+        it 'つぶやき一覧画面にリダイレクトされる(HTTPステータスコード302が返される)' do
+          post users_tweets_path, params: invalid_params, headers: { "HTTP_REFERER" => referrer_url }
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(referrer_url)
+        end
+
+        it 'エラーメッセージ「投稿内容は255文字以内で入力してください」が表示される。' do
+          post users_tweets_path, params: invalid_params, headers: { "HTTP_REFERER" => referrer_url }
+          follow_redirect!
+          expect(response.body).to include("投稿内容は255文字以内で入力してください")
+        end
+      end
+    end
+  end
+
+  describe "GET / edit" do
+    context 'ログインしているユーザーが つぶやき編集画面にアクセスした場合' do
+      before do
+        sign_in user
+      end
+
+      it 'つぶやき編集画面にアクセスした場合(HTTPステータスコード200が返される)' do
+        get edit_users_tweet_path(tweet.id), xhr: true
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログインしていないユーザーがつぶやき編集画面にアクセスした場合' do
+      before do
+        sign_out user
+      end
+
+      it 'ログイン画面にリダイレクトされる(HTTPステータスコード302が返される)' do
+        get edit_users_tweet_path(tweet.id)
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'エラーメッセージ「ログインもしくはアカウント登録してください。」が表示される' do
+        get edit_users_tweet_path(tweet.id)
+        follow_redirect!
+        expect(response.body).to include("ログインもしくはアカウント登録してください。")
+      end
+    end
+
+    context 'ログインしているユーザーが他ユーザーのつぶやき編集画面にアクセスした場合' do
+      before do
+        sign_in user
+      end
+
+      it 'ログイン画面にリダイレクトされる(HTTPステータスコード302が返される)' do
+        get edit_users_tweet_path(another_user_tweet.id)
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(users_dash_boards_path)
+      end
+
+      it 'エラーメッセージ「ログインもしくはアカウント登録してください。」が表示される' do
+        get edit_users_tweet_path(another_user_tweet.id)
+        follow_redirect!
+        expect(response.body).to include("アクセスできません")
+      end
+    end
+  end
+
+  describe "PATCH / update" do
+    before do
+      sign_in user
+    end
+
+    context "ログインしているユーザーがつぶやきを更新した場合" do
+      it '記事詳細画面にリダイレクトされる(HTTPステータスコード302が表示される)' do
+        patch users_tweet_path(tweet.id), params: valid_params
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(users_tweets_url)
+      end
+
+      it 'メッセージ「編集成功しました。」が表示される' do
+        patch users_tweet_path(tweet.id), params: valid_params
+        follow_redirect!
+        expect(response.body).to include("編集成功しました。")
+      end
+
+      it 'つぶやきが更新される(更新時に入力した文字列がデータベースに反映される)' do
+        new_post = "Update test tweet"
+        patch users_tweet_path(tweet.id), params: { tweet: { post: new_post} }
+        expect(tweet.reload.post).to eq(new_post)
+      end
+    end
+
+    context "ログインしているユーザーが空文字でつぶやきを更新した場合" do
+      it "つぶやき編集画面から遷移しない(HTTPステータスコード200が返される)" do
+        patch users_tweet_path(tweet.id), params: nil_params, xhr: true
+        expect(response).to have_http_status(200)
+      end
+
+      it "エラーメッセージ「投稿内容を入力してください」が表示される" do
+        patch users_tweet_path(tweet.id), params: nil_params, xhr: true
+        expect(response.body).to include("投稿内容を入力してください")
+      end
+    end
+
+    context "ログインしているユーザーが255文字以上でつぶやきを更新した場合" do
+      it "つぶやき編集画面から遷移しない(HTTPステータスコード200が返される)" do
+        patch users_tweet_path(tweet.id), params: invalid_params, xhr: true
+        expect(response).to have_http_status(200)
+      end
+
+      it "エラーメッセージ「投稿内容は255文字以内で入力してください」が表示される" do
+        patch users_tweet_path(tweet.id), params: invalid_params, xhr: true
+        expect(response.body).to include("投稿内容は255文字以内で入力してください")
+      end
+    end
+  end
+
+  describe "DELETE / destroy" do
+    before do
+      sign_in user
+      @tweet = FactoryBot.create(:tweet, user: user)
+    end
+
+    context 'ログインしているユーザーがつぶやきを削除した場合' do
+      it 'つぶやき一覧画面にリダイレクトされる' do
+        delete users_tweet_path(@tweet.id)
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to users_tweets_url
+      end
+
+      it 'メッセージ「削除に成功しました。」が表示される' do
+        delete users_tweet_path(@tweet.id)
+        follow_redirect!
+        expect(response.body).to include("削除に成功しました。")
+      end
+
+      it 'つぶやきが削除される(データベースからつぶやきが１つ減る)' do
+        expect { delete users_tweet_path(@tweet.id) }.to change(Tweet, :count).by(-1)
+      end
+
+      context "ログインしているユーザーが別のユーザーのつぶやきを削除の操作をした場合" do
+        it "ユーザーダッシュボードにリダイレクトされる(HTTPステータスコード302)" do
+          delete users_tweet_path(another_user_tweet.id)
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(users_dash_boards_path)
+        end
+
+        it "エラーメッセージ「アクセスできません」が表示される" do
+          delete users_tweet_path(another_user_tweet.id)
+          follow_redirect!
+          expect(response.body).to include("アクセスできません")
+        end
+      end
+    end
+  end
+
+  describe "index_user" do
+    context 'ログインしているユーザーが個別のユーザーのつぶやき一覧画面に遷移した場合' do
+      before do
+        sign_in user
+      end
+
+      it '個別のユーザーのつぶやき一覧画面が表示される(HTTPステータスコード200が返される)' do
+        get index_user_users_tweet_path(user.id)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログインしていないユーザーが個別のユーザーのつぶやき一覧画面に遷移した場合' do
+      before do
+        sign_out user
+      end
+
+      it 'ログイン画面にリダイレクトされる(HTTPステータスコード302が返される)' do
+        get index_user_users_tweet_path(user.id)
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "エラーメッセージ「ログインもしくはアカウント登録してください。」が表示される" do
+        get index_user_users_tweet_path(user.id)
+        follow_redirect!
+        expect(response.body).to include("ログインもしくはアカウント登録してください。")
+      end
+    end
+  end
 end
+

--- a/spec/requests/users/tweets_spec.rb
+++ b/spec/requests/users/tweets_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe "Users::Tweets", type: :request do
     context 'ログインユーザーが新規投稿をした場合' do
       subject { post users_tweets_path, params: valid_params, headers: { "HTTP_REFERER" => referrer_url } }
 
-      it 'HTTPステータスコード302が返される' do
+      it 'HTTPステータスコード200が返される' do
         subject
-        expect(response).to have_http_status(302)
+        expect(response).to have_http_status(200)
         expect(response).to redirect_to(referrer_url)
       end
 
@@ -188,9 +188,9 @@ RSpec.describe "Users::Tweets", type: :request do
     end
 
     context "ログインユーザーがつぶやきを更新した場合" do
-      it 'HTTPステータスコード302が返される' do
+      it 'HTTPステータスコード200が返される' do
         patch users_tweet_path(tweet.id), params: valid_params
-        expect(response).to have_http_status(302)
+        expect(response).to have_http_status(200)
         expect(response).to redirect_to(users_tweets_url)
       end
 
@@ -208,16 +208,16 @@ RSpec.describe "Users::Tweets", type: :request do
     end
 
     context "空文字でつぶやきを更新した場合" do  
-      it "HTTPステータスコード200が返される" do
+      it "HTTPステータスコード302が返される" do
         patch users_tweet_path(tweet.id), params: nil_params, xhr: true
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(302)
       end
     end
 
     context "255文字以上でつぶやきを更新した場合" do
-      it "HTTPステータスコード200が返される" do
+      it "HTTPステータスコード302が返される" do
         patch users_tweet_path(tweet.id), params: invalid_params, xhr: true
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(302)
       end 
     end
   end
@@ -231,9 +231,9 @@ RSpec.describe "Users::Tweets", type: :request do
     context 'ログインユーザーがつぶやきを削除した場合' do
       subject { delete users_tweet_path(@tweet.id) }
 
-      it 'HTTPステータスコード302が返される' do
+      it 'HTTPステータスコード200が返される' do
         subject
-        expect(response).to have_http_status(302)
+        expect(response).to have_http_status(200)
         expect(response).to redirect_to users_tweets_url
       end
 

--- a/spec/requests/users/tweets_spec.rb
+++ b/spec/requests/users/tweets_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe "Users::Tweets", type: :request do
 
       it 'エラーメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:alert]).to be_present
       end
     end
@@ -76,12 +75,11 @@ RSpec.describe "Users::Tweets", type: :request do
     end
     
     context 'ログインユーザーが新規投稿をした場合' do
-      subject { post users_tweets_path, params: valid_params, headers: { "HTTP_REFERER" => referrer_url } }
+      subject { post users_tweets_path, params: valid_params }
 
       it 'HTTPステータスコード200が返される' do
         subject
         expect(response).to have_http_status(200)
-        expect(response).to redirect_to(referrer_url)
       end
 
       it 'つぶやきがデータベースに保存される' do
@@ -90,39 +88,36 @@ RSpec.describe "Users::Tweets", type: :request do
 
       it 'サクセスメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:success]).to be_present
       end
     end
 
     context '空文字で新規投稿をした場合' do
-      subject { post users_tweets_path, params: nil_params, headers: { "HTTP_REFERER" => referrer_url } }
+      subject { post users_tweets_path, params: nil_params }
 
       it 'HTTPステータスコード302が返される' do
         subject
         expect(response).to have_http_status(302)
-        expect(response).to redirect_to(referrer_url)
+        expect(response).to redirect_to(users_tweets_path)
       end
 
       it 'エラーメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:error]).to be_present
       end
     end
 
     context '255文字以上の新規投稿をした場合' do
-      subject { post users_tweets_path, params: invalid_params, headers: { "HTTP_REFERER" => referrer_url } }
+      subject { post users_tweets_path, params: invalid_params }
 
       it 'HTTPステータスコード302が返される' do
         subject
         expect(response).to have_http_status(302)
-        expect(response).to redirect_to(referrer_url)
+        expect(response).to redirect_to(users_tweets_path)
       end
 
       it 'エラーメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:error]).to be_present
       end
     end
@@ -156,7 +151,6 @@ RSpec.describe "Users::Tweets", type: :request do
 
       it 'エラーメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:alert]).to be_present
       end
     end
@@ -176,7 +170,6 @@ RSpec.describe "Users::Tweets", type: :request do
 
       it 'エラーメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:alert]).to be_present
       end
     end
@@ -191,12 +184,10 @@ RSpec.describe "Users::Tweets", type: :request do
       it 'HTTPステータスコード200が返される' do
         patch users_tweet_path(tweet.id), params: valid_params
         expect(response).to have_http_status(200)
-        expect(response).to redirect_to(users_tweets_url)
       end
 
       it 'サクセスメッセージが存在する' do
         patch users_tweet_path(tweet.id), params: valid_params
-        follow_redirect!
         expect(flash[:success]).to be_present
       end
 
@@ -209,15 +200,17 @@ RSpec.describe "Users::Tweets", type: :request do
 
     context "空文字でつぶやきを更新した場合" do  
       it "HTTPステータスコード302が返される" do
-        patch users_tweet_path(tweet.id), params: nil_params, xhr: true
+        patch users_tweet_path(tweet.id), params: nil_params
         expect(response).to have_http_status(302)
+        expect(response).to redirect_to(users_tweets_path)
       end
     end
 
     context "255文字以上でつぶやきを更新した場合" do
       it "HTTPステータスコード302が返される" do
-        patch users_tweet_path(tweet.id), params: invalid_params, xhr: true
+        patch users_tweet_path(tweet.id), params: invalid_params
         expect(response).to have_http_status(302)
+        expect(response).to redirect_to(users_tweets_path)
       end 
     end
   end
@@ -234,12 +227,10 @@ RSpec.describe "Users::Tweets", type: :request do
       it 'HTTPステータスコード200が返される' do
         subject
         expect(response).to have_http_status(200)
-        expect(response).to redirect_to users_tweets_url
       end
 
       it 'サクセスメッセージが存在する' do
         subject
-        follow_redirect!
         expect(flash[:success]).to be_present
       end
 
@@ -259,7 +250,6 @@ RSpec.describe "Users::Tweets", type: :request do
 
       it "エラーメッセージが存在する" do
         subject
-        follow_redirect!
         expect(flash[:alert]).to be_present
       end
     end
@@ -268,7 +258,7 @@ RSpec.describe "Users::Tweets", type: :request do
   describe "index_user" do
     subject { get index_user_users_tweet_path(user.id)}
 
-    context 'ログインユーザーが個別のユーザーの一覧画面にアクセスした場合' do
+    context 'ログインユーザーが個別のユーザーのつぶやき一覧画面にアクセスした場合' do
       before do
         sign_in user
       end
@@ -279,7 +269,7 @@ RSpec.describe "Users::Tweets", type: :request do
       end
     end
 
-    context 'ログインしていないユーザーが個別のユーザーの一覧画面にアクセスした場合' do
+    context 'ログインしていないユーザーが個別のユーザーのつぶやき一覧画面にアクセスした場合' do
       before do
         sign_out user
       end
@@ -292,10 +282,8 @@ RSpec.describe "Users::Tweets", type: :request do
 
       it "エラーメッセージが存在する" do
         subject
-        follow_redirect!
         expect(flash[:alert]).to be_present
       end
     end
   end
 end
-


### PR DESCRIPTION
,▫️概要

つぶやき機能のRequestスペックを追加

———-

◽️タスク・仕様書

下記がRequestSpecのテスト仕様書になります。

https://docs.google.com/spreadsheets/d/16BqCFNKKG0tpCQMsiXOKIhEDXpK4KOTJ0UDsiEIvhdE/edit?gid=581082379#gid=581082379

———-

◽️実装内容・手法

つぶやき機能のリクエストに対して、正常なレスポンスが返ってくるかテストしています。
端的に言えば、下記のような点をテストしています(詳細はテスト仕様書)。

・CRUD機能が正常に動作するか
・バリデーションが動作するか、動作した場合はエラーメッセージが表示されるか
・認証機能が動作するか(ログインしてないユーザーが、ログインユーザーのページに勝手にアクセスできないか)など

————

▫️補足事項

下記のコマンドで動作確認をお願いします

bin/docker/bundle/exec rspec spec/requests/users/tweets_spec.rb

・動作確認の動画

https://github.com/user-attachments/assets/3918117e-fa0e-428d-a4a7-c849b6292c3e

・テスト結果

![テスト結果](https://github.com/user-attachments/assets/0b741f81-fc5b-409a-bfc2-899e6d8470f6)

